### PR TITLE
Updated pause logic

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -3,12 +3,12 @@
         "contract/valory/conditional_tokens/0.1.0": "bafybeic5hrqfz7smtkbq4hmxfvx4f2fm64i2c7cyr6jwm4o4tz4lalenzq",
         "contract/valory/fpmm_deterministic_factory/0.1.0": "bafybeif7hgwamqm6iljhtr32ap6eazn5yhmxrtlvicmpo746gv2s4tyzqq",
         "contract/valory/realtio/0.1.0": "bafybeigsciwpawqiyxtk7klpnx6vyaz4nic5s6afl4eahab5ub4hftu4du",
-        "skill/valory/market_creation_manager_abci/0.1.0": "bafybeifwno2wfewpcvh6ypxhx2kbqi6pt7al2hjjpogxglilbxjibarmnm",
-        "skill/valory/market_maker_abci/0.1.0": "bafybeiakglhkmkryr23gl6afgfnhjuzjluytvpcexu3p6r2o4cdwjfw7x4",
-        "agent/valory/market_maker/0.1.0": "bafybeiajtiybsoms7vr5rljmuenva6vgf2t7p734bogdlnzb2qrf7zox74",
-        "service/valory/market_maker/0.1.0": "bafybeiahwqswc24jvcadad3hyjbundqn2zenklh5amerlv4v23hkaso2ta",
+        "skill/valory/market_creation_manager_abci/0.1.0": "bafybeie2tqig6iu6d4mdovyzninpkcbt4udz3us6xg46ltcv6x3grumajq",
+        "skill/valory/market_maker_abci/0.1.0": "bafybeieezpvmyghf5qhss2jpm7s4qr7xgomr3u34wkuhsjiulbnvt62yxi",
+        "agent/valory/market_maker/0.1.0": "bafybeig7kydtrvy6zg2xvfmrvnitu4lm4wbn5zv6bgqal276bcisiacod4",
+        "service/valory/market_maker/0.1.0": "bafybeihgppru2nzlg65z4mylopomzvu4s32zanh36vamk27afpvr566iga",
         "contract/valory/wxdai/0.1.0": "bafybeihn5dn4kbgybibgy7pjc22anuc5kdyfazv7ktz3guqfby2cwznnky",
-        "skill/valory/market_validation_abci/0.1.0": "bafybeibpap5cezvrpz3kjigrvh7zjzhh5doh3hh77wjmjid4dvwwazs6my",
+        "skill/valory/market_validation_abci/0.1.0": "bafybeidl664rt2kzefnaxrde5w4df2ldum54ljrdc5nfaexlb5y3uivmhu",
         "contract/valory/fpmm/0.1.0": "bafybeid4gqlupq63g2vqehli6jsm5m45we5i2dhnj5faoxsazjphk4zw6m"
     },
     "third_party": {

--- a/packages/valory/agents/market_maker/aea-config.yaml
+++ b/packages/valory/agents/market_maker/aea-config.yaml
@@ -37,10 +37,10 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeih3bwx5apteinnoxts7sqmjlskntdbo7vvnmdbs5noo2pv76by7fu
 - valory/abstract_round_abci:0.1.0:bafybeibqpzbklnljvtc67yon4ciijxj75d7vazm7rurcvbbfnk6jtudukm
-- valory/market_maker_abci:0.1.0:bafybeiakglhkmkryr23gl6afgfnhjuzjluytvpcexu3p6r2o4cdwjfw7x4
+- valory/market_maker_abci:0.1.0:bafybeieezpvmyghf5qhss2jpm7s4qr7xgomr3u34wkuhsjiulbnvt62yxi
 - valory/registration_abci:0.1.0:bafybeia25gpusnkakb2dp4heqkwtuftbc2apppq3i4bds6sphltsovgzvi
-- valory/market_creation_manager_abci:0.1.0:bafybeifwno2wfewpcvh6ypxhx2kbqi6pt7al2hjjpogxglilbxjibarmnm
-- valory/market_validation_abci:0.1.0:bafybeibpap5cezvrpz3kjigrvh7zjzhh5doh3hh77wjmjid4dvwwazs6my
+- valory/market_creation_manager_abci:0.1.0:bafybeie2tqig6iu6d4mdovyzninpkcbt4udz3us6xg46ltcv6x3grumajq
+- valory/market_validation_abci:0.1.0:bafybeidl664rt2kzefnaxrde5w4df2ldum54ljrdc5nfaexlb5y3uivmhu
 - valory/reset_pause_abci:0.1.0:bafybeigzvwbzktclahjbsyiwqnj6poree4iveon5pric6s5ixb6wrhkdhq
 - valory/termination_abci:0.1.0:bafybeibcdgnarxyyqexncpfewcemraryywtwueuv7qthsjuean5l77lp2e
 - valory/transaction_settlement_abci:0.1.0:bafybeiepus7qsa47gt7dyk32gaqsoae6whjoxfnplttulxrvmcauyerrdm

--- a/packages/valory/agents/market_maker/aea-config.yaml
+++ b/packages/valory/agents/market_maker/aea-config.yaml
@@ -165,8 +165,8 @@ models:
       arbitrator_contract: ${str:0xe40dd83a262da3f56976038f1554fe541fa75ecd}
       multisend_address: ${str:0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761}
       on_chain_service_id: ${int:null}
-      reset_tendermint_after: ${int:2}
-      reset_pause_duration: ${int:30}
+      reset_tendermint_after: ${int:1}
+      reset_pause_duration: ${int:1800}
       service_id: market_maker
       service_registry_address: ${str:0x1cEe30D08943EB58EFF84DD1AB44a6ee6FEff63a}
       setup:

--- a/packages/valory/services/market_maker/service.yaml
+++ b/packages/valory/services/market_maker/service.yaml
@@ -59,8 +59,8 @@ models:
       arbitrator_contract: ${ARBITRATOR_CONTRACT:str:0xe40dd83a262da3f56976038f1554fe541fa75ecd}
       multisend_address: ${MULTISEND_ADDRESS:str:0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761}
       on_chain_service_id: ${ON_CHAIN_SERVICE_ID:int:null}
-      reset_tendermint_after: ${RESET_TENDERMINT_AFTER:int:2}
-      reset_pause_duration: ${RESET_PAUSE_DURATION:int:10}
+      reset_tendermint_after: ${RESET_TENDERMINT_AFTER:int:1}
+      reset_pause_duration: ${RESET_PAUSE_DURATION:int:1800}
       service_id: market_maker
       service_registry_address: ${SERVICE_REGISTRY_ADDRESS:str:0x1cEe30D08943EB58EFF84DD1AB44a6ee6FEff63a}
       setup:

--- a/packages/valory/services/market_maker/service.yaml
+++ b/packages/valory/services/market_maker/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibwz3af6326msp4h3kqehijvmyhaytvyfbo3o2npc2w4b6zrg6pfq
 fingerprint_ignore_patterns: []
-agent: valory/market_maker:0.1.0:bafybeiajtiybsoms7vr5rljmuenva6vgf2t7p734bogdlnzb2qrf7zox74
+agent: valory/market_maker:0.1.0:bafybeig7kydtrvy6zg2xvfmrvnitu4lm4wbn5zv6bgqal276bcisiacod4
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/market_creation_manager_abci/rounds.py
+++ b/packages/valory/skills/market_creation_manager_abci/rounds.py
@@ -501,7 +501,7 @@ class MarketCreationManagerAbciApp(AbciApp[Event]):
             Event.ROUND_TIMEOUT: CollectRandomnessRound,
         },
         MarketProposalRound: {
-            Event.DONE: RetrieveApprovedMarketRound,
+            Event.DONE: CollectRandomnessRound,
             Event.NO_MAJORITY: CollectRandomnessRound,
             Event.ROUND_TIMEOUT: CollectRandomnessRound,
             Event.DID_NOT_SEND: CollectRandomnessRound,

--- a/packages/valory/skills/market_creation_manager_abci/skill.yaml
+++ b/packages/valory/skills/market_creation_manager_abci/skill.yaml
@@ -138,8 +138,8 @@ models:
       on_chain_service_id: null
       request_retry_delay: 1.0
       request_timeout: 10.0
-      reset_pause_duration: 10
-      reset_tendermint_after: 2
+      reset_pause_duration: 1800
+      reset_tendermint_after: 1
       retry_attempts: 400
       retry_timeout: 3
       round_timeout_seconds: 60.0

--- a/packages/valory/skills/market_creation_manager_abci/skill.yaml
+++ b/packages/valory/skills/market_creation_manager_abci/skill.yaml
@@ -14,7 +14,7 @@ fingerprint:
   handlers.py: bafybeietxjfli2i57kb7heoy772rcq2znusl36gg7jjj5g3pddw7egny3q
   models.py: bafybeia226bfyqfnzkkp24wmabaof4umi7lqnjtmhb63goszboqk2krqsm
   payloads.py: bafybeib57gmbwstx646qxvxxl62n6of4vo2ei2nl32ogo5vhi3ukz6ldqe
-  rounds.py: bafybeibcrli5p53g3eiouop3cdncnhk667sivaky5btuwxy4dxaudwiooa
+  rounds.py: bafybeidldfmzrud6sa3f5mpxa2p2nr5e6tzipuvydrxu5n6bfgar6qntxq
   tests/__init__.py: bafybeihfxvqnyfly72tbxnnnglshcilm2kanihqnjiasvcz3ec3csw32ti
 fingerprint_ignore_patterns: []
 connections:

--- a/packages/valory/skills/market_maker_abci/composition.py
+++ b/packages/valory/skills/market_maker_abci/composition.py
@@ -49,7 +49,7 @@ abci_app_transition_mapping: AbciAppTransitionMapping = {
     MarketCreationManagerAbci.FinishedMarketCreationManagerRound: TransactionSettlementAbci.RandomnessTransactionSubmissionRound,
     MarketCreationManagerAbci.FinishedWithRemoveFundingRound: TransactionSettlementAbci.RandomnessTransactionSubmissionRound,
     TransactionSettlementAbci.FinishedTransactionSubmissionRound: MarketValidationAbci.MarketValidationRound,
-    MarketValidationAbci.FinishedMarketValidationRound: ResetAndPauseRound,
+    MarketValidationAbci.FinishedMarketValidationRound: MarketCreationManagerAbci.CollectRandomnessRound,
     TransactionSettlementAbci.FailedRound: ResetAndPauseRound,
     FinishedResetAndPauseRound: MarketCreationManagerAbci.CollectRandomnessRound,
     FinishedResetAndPauseErrorRound: RegistrationRound,

--- a/packages/valory/skills/market_maker_abci/skill.yaml
+++ b/packages/valory/skills/market_maker_abci/skill.yaml
@@ -9,7 +9,7 @@ fingerprint:
   README.md: bafybeiaa46uuvl2cbxvgdqrqhfh5te6z2iinqktaoz3sycjd6wpar2nfhy
   __init__.py: bafybeie36nhohbz4t6hngy42nw7coe2hwrprywo4n6xmwqjkfz7ni3n6sq
   behaviours.py: bafybeid4jy4bx5djlksbyz7nog7ktynbnkwmjymityrbqzfxlbipiex3wi
-  composition.py: bafybeigr3xuxpgnor2erj4xdoqlhyvqckxhlkp2o4ir6xxo2jrwrkbnpjm
+  composition.py: bafybeihlmnnq3g7rtos7bcdlxag5emkxi3rdnnvm6pbcqvba2cf5hbbg4m
   dialogues.py: bafybeicintyylxt4nd5gcufh3rehbxr5jvdn6un7wvaoel7hvj3dmurlpy
   fsm_specification.yaml: bafybeicvtoez7ahmyl25h66edgjywx5ymxtqnyexzq73ouyu2p6smi3uoa
   handlers.py: bafybeidlgouig5odju36dkjl5vdqx6mqrukaoyn2chnl5dv2ca6owqlecm
@@ -23,8 +23,8 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeibqpzbklnljvtc67yon4ciijxj75d7vazm7rurcvbbfnk6jtudukm
 - valory/registration_abci:0.1.0:bafybeia25gpusnkakb2dp4heqkwtuftbc2apppq3i4bds6sphltsovgzvi
 - valory/reset_pause_abci:0.1.0:bafybeigzvwbzktclahjbsyiwqnj6poree4iveon5pric6s5ixb6wrhkdhq
-- valory/market_creation_manager_abci:0.1.0:bafybeifwno2wfewpcvh6ypxhx2kbqi6pt7al2hjjpogxglilbxjibarmnm
-- valory/market_validation_abci:0.1.0:bafybeibpap5cezvrpz3kjigrvh7zjzhh5doh3hh77wjmjid4dvwwazs6my
+- valory/market_creation_manager_abci:0.1.0:bafybeie2tqig6iu6d4mdovyzninpkcbt4udz3us6xg46ltcv6x3grumajq
+- valory/market_validation_abci:0.1.0:bafybeidl664rt2kzefnaxrde5w4df2ldum54ljrdc5nfaexlb5y3uivmhu
 - valory/termination_abci:0.1.0:bafybeibcdgnarxyyqexncpfewcemraryywtwueuv7qthsjuean5l77lp2e
 - valory/transaction_settlement_abci:0.1.0:bafybeiepus7qsa47gt7dyk32gaqsoae6whjoxfnplttulxrvmcauyerrdm
 behaviours:

--- a/packages/valory/skills/market_maker_abci/skill.yaml
+++ b/packages/valory/skills/market_maker_abci/skill.yaml
@@ -134,8 +134,8 @@ models:
       on_chain_service_id: null
       request_retry_delay: 1.0
       request_timeout: 10.0
-      reset_pause_duration: 10
-      reset_tendermint_after: 2
+      reset_pause_duration: 1800
+      reset_tendermint_after: 1
       retry_attempts: 400
       retry_timeout: 3
       round_timeout_seconds: 60.0

--- a/packages/valory/skills/market_validation_abci/skill.yaml
+++ b/packages/valory/skills/market_validation_abci/skill.yaml
@@ -103,8 +103,8 @@ models:
       on_chain_service_id: null
       request_retry_delay: 1.0
       request_timeout: 10.0
-      reset_pause_duration: 10
-      reset_tendermint_after: 2
+      reset_pause_duration: 1800
+      reset_tendermint_after: 1
       retry_attempts: 400
       retry_timeout: 3
       round_timeout_seconds: 60.0


### PR DESCRIPTION
Updated pause timer and rewired the FSM to allow the service being on all the time without exhausting RPC calls.

The following behaviour is achieved:

1. If any of these operations occurs:
    - Propose a new market
    - Create a new marked on-chain (user-approved)
    - Exchange DAI for WXDAI
    - Remove funds
   then, go to the entry point of the FSM (CollectRandomness)

2. If none of these operations occurs, wait 1800 seconds on ResetAndPause.