### PR TITLE
Upgrade reality.io bond from $0.1 to $10

### DIFF
--- a/packages/valory/agents/market_maker/aea-config.yaml
+++ b/packages/valory/agents/market_maker/aea-config.yaml
@@ -207,7 +207,7 @@ models:
       use_termination: ${bool:false}
       use_slashing: ${bool:false}
       slash_cooldown_hours: ${int:3}
-      close_question_bond: ${int:1000000000000000}
+      close_question_bond: ${int:100000000000000000}
       questions_to_close_batch_size: ${int:1}
       slash_threshold_amount: ${int:10000000000000000}
       light_slash_unit_amount: ${int:5000000000000000}

--- a/packages/valory/services/market_maker/service.yaml
+++ b/packages/valory/services/market_maker/service.yaml
@@ -86,7 +86,7 @@ models:
       tendermint_check_sleep_delay: ${TENDERMINT_CHECK_SLEEP_DELAY:int:3}
       tendermint_com_url: ${TENDERMINT_COM_URL:str:http://localhost:8080}
       tendermint_max_retries: ${TENDERMINT_MAX_RETRIES:int:5}
-      close_question_bond: ${CLOSE_QUESTION_BOND:int:1000000000000000}
+      close_question_bond: ${CLOSE_QUESTION_BOND:int:100000000000000000}
       questions_to_close_batch_size: ${QUESTIONS_TO_CLOSE_BATCH_SIZE:int:1}
       tendermint_url: ${TENDERMINT_URL:str:http://localhost:26657}
       tendermint_p2p_url: ${TENDERMINT_P2P_URL:str:localhost:26656}

--- a/packages/valory/skills/market_creation_manager_abci/skill.yaml
+++ b/packages/valory/skills/market_creation_manager_abci/skill.yaml
@@ -205,7 +205,7 @@ models:
       tendermint_p2p_url: localhost:26656
       tendermint_url: http://localhost:26657
       tx_timeout: 10.0
-      close_question_bond: 1000000000000000
+      close_question_bond: 100000000000000000
       questions_to_close_batch_size: 1
       validate_timeout: 1205
       use_termination: false

--- a/packages/valory/skills/market_maker_abci/skill.yaml
+++ b/packages/valory/skills/market_maker_abci/skill.yaml
@@ -207,7 +207,7 @@ models:
       google_engine_id: google_engine_id
       openai_api_key: openai_api_key
       xdai_threshold: 1000000000000000000
-      close_question_bond: 1000000000000000
+      close_question_bond: 100000000000000000
       slash_threshold_amount: 10000000000000000
       light_slash_unit_amount: 5000000000000000
       serious_slash_unit_amount: 8000000000000000


### PR DESCRIPTION
Once market-creator uses the new OFV mech (https://github.com/valory-xyz/mech/pull/247), market resolution accuracy should go from 70% -> 90%. We hope to correct the remaining errors by incentivising Kleros community participation in resolutions by posting sufficiently large bonds (10 xDai)

Note: this will result in the deployed market-creator now losing bonds for incorrect resolutions. How this will be funded is being discussed separately 😃.