### PR TITLE
Add reality.eth answer question bounty

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Next, prepare the [Safe](https://safe.global/). The trader agent runs as part of
 which is an [autonomous service](https://docs.autonolas.network/open-autonomy/get_started/what_is_an_agent_service/) 
 represented on-chain in the [Autonolas Protocol](https://docs.autonolas.network/protocol/) by a [Safe](https://safe.global/) multisig. Follow the next steps to obtain a **Safe address** corresponding to your agent address:
 
-1. Visit https://registry.olas.network/services/mint and connect to the Gnosis network. We recommend connecting using a wallet with a Gnosis EOA account that you own.
+1. Visit https://registry.olas.network/gnosis/services/mint and connect to the Gnosis network. We recommend connecting using a wallet with a Gnosis EOA account that you own.
 2. Fill in the following fields:
     - *"Owner address"*: a Gnosis address for which you will be able to sign later using a supported wallet. If you want to use the address you are connected to, click on *"Prefill Address"*.
     - Click on *"Generate Hash & File"* and enter the value corresponding to the `service/valory/trader/0.1.0` key in [`packages.json`](https://github.com/valory-xyz/trader/blob/main/packages/packages.json)

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -3,10 +3,10 @@
         "contract/valory/fpmm_deterministic_factory/0.1.0": "bafybeigjfuahxhb2y4q5ueayry55boaojcryoamwr6fshgayf5s762vpl4",
         "contract/valory/wxdai/0.1.0": "bafybeidalocwbhmbto6ii6adldtpcughtdt6j3v4tv36utevjk2wrdyqie",
         "contract/valory/fpmm/0.1.0": "bafybeiai2ruj27nnglvn7yc5atojyojo3fkmofw6wrjgz2ybps2uwdizx4",
-        "skill/valory/market_creation_manager_abci/0.1.0": "bafybeidzxfrtwdd65c5uqbcwj5csw6dnrmdcoi7lb2w4hc5rwouwtzh6ee",
-        "skill/valory/market_maker_abci/0.1.0": "bafybeiguuoyykob2kxrnvvqkxl64vs37of6r3hrevc2qfbmtw5yjhliohi",
-        "agent/valory/market_maker/0.1.0": "bafybeidstcny2k2brq3e7wnsr72lugj3rq3nzy7pjwswnf5evknc2i2ht4",
-        "service/valory/market_maker/0.1.0": "bafybeibtlh3bglhpuivnkpmpxxzul5sbv6xuaspfdakm5smhpv47bl644m"
+        "skill/valory/market_creation_manager_abci/0.1.0": "bafybeigxyy2mr2skgkthqu5qmtkrhid7dwgdn4hylhpkoeex3g6zfgua3m",
+        "skill/valory/market_maker_abci/0.1.0": "bafybeieb7ar4k6axttw5czigtbkzilzbavpa7rilkdfj42itlxsjmmdijq",
+        "agent/valory/market_maker/0.1.0": "bafybeia3aoiq4w5v73ys5xi4lzbz7fgwtnhlxpmr2r5t62wuugm4slgkze",
+        "service/valory/market_maker/0.1.0": "bafybeig6aakuowznozsfmz3fy77uvqjm2jtj7tj2wqmkfwhiusuxvvucmm"
     },
     "third_party": {
         "protocol/valory/contract_api/1.0.0": "bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i",

--- a/packages/valory/agents/market_maker/aea-config.yaml
+++ b/packages/valory/agents/market_maker/aea-config.yaml
@@ -207,7 +207,7 @@ models:
       use_termination: ${bool:false}
       use_slashing: ${bool:false}
       slash_cooldown_hours: ${int:3}
-      close_question_bond: ${int:1000000000000000}
+      realitio_answer_question_bond: ${int:1000000000000000}
       questions_to_close_batch_size: ${int:1}
       slash_threshold_amount: ${int:10000000000000000}
       light_slash_unit_amount: ${int:5000000000000000}

--- a/packages/valory/agents/market_maker/aea-config.yaml
+++ b/packages/valory/agents/market_maker/aea-config.yaml
@@ -37,9 +37,9 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeieh4ei3qdelmacnm7vwq57phoewgumr3udvxt6pybmuggwc3yk65q
 - valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
-- valory/market_maker_abci:0.1.0:bafybeiguuoyykob2kxrnvvqkxl64vs37of6r3hrevc2qfbmtw5yjhliohi
+- valory/market_maker_abci:0.1.0:bafybeieb7ar4k6axttw5czigtbkzilzbavpa7rilkdfj42itlxsjmmdijq
 - valory/registration_abci:0.1.0:bafybeieu7vq3pyns4t5ty6u3sbmpkd7yznpg3rmqifoz3jhy7pmqyg3w6q
-- valory/market_creation_manager_abci:0.1.0:bafybeidzxfrtwdd65c5uqbcwj5csw6dnrmdcoi7lb2w4hc5rwouwtzh6ee
+- valory/market_creation_manager_abci:0.1.0:bafybeigxyy2mr2skgkthqu5qmtkrhid7dwgdn4hylhpkoeex3g6zfgua3m
 - valory/reset_pause_abci:0.1.0:bafybeiameewywqigpupy3u2iwnkfczeiiucue74x2l5lbge74rmw6bgaie
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/transaction_settlement_abci:0.1.0:bafybeic3tccdjypuge2lewtlgprwkbb53lhgsgn7oiwzyrcrrptrbeyote
@@ -208,6 +208,7 @@ models:
       use_slashing: ${bool:false}
       slash_cooldown_hours: ${int:3}
       realitio_answer_question_bond: ${int:1000000000000000}
+      realitio_answer_question_bounty: ${int:0}
       questions_to_close_batch_size: ${int:1}
       slash_threshold_amount: ${int:10000000000000000}
       light_slash_unit_amount: ${int:5000000000000000}

--- a/packages/valory/services/market_maker/service.yaml
+++ b/packages/valory/services/market_maker/service.yaml
@@ -86,7 +86,7 @@ models:
       tendermint_check_sleep_delay: ${TENDERMINT_CHECK_SLEEP_DELAY:int:3}
       tendermint_com_url: ${TENDERMINT_COM_URL:str:http://localhost:8080}
       tendermint_max_retries: ${TENDERMINT_MAX_RETRIES:int:5}
-      close_question_bond: ${CLOSE_QUESTION_BOND:int:1000000000000000}
+      realitio_answer_question_bond: ${REALITIO_ANSWER_QUESTION_BOND:int:1000000000000000}
       questions_to_close_batch_size: ${QUESTIONS_TO_CLOSE_BATCH_SIZE:int:1}
       tendermint_url: ${TENDERMINT_URL:str:http://localhost:26657}
       tendermint_p2p_url: ${TENDERMINT_P2P_URL:str:localhost:26656}

--- a/packages/valory/services/market_maker/service.yaml
+++ b/packages/valory/services/market_maker/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibwz3af6326msp4h3kqehijvmyhaytvyfbo3o2npc2w4b6zrg6pfq
 fingerprint_ignore_patterns: []
-agent: valory/market_maker:0.1.0:bafybeidstcny2k2brq3e7wnsr72lugj3rq3nzy7pjwswnf5evknc2i2ht4
+agent: valory/market_maker:0.1.0:bafybeia3aoiq4w5v73ys5xi4lzbz7fgwtnhlxpmr2r5t62wuugm4slgkze
 number_of_agents: 1
 deployment:
   agent:
@@ -87,6 +87,7 @@ models:
       tendermint_com_url: ${TENDERMINT_COM_URL:str:http://localhost:8080}
       tendermint_max_retries: ${TENDERMINT_MAX_RETRIES:int:5}
       realitio_answer_question_bond: ${REALITIO_ANSWER_QUESTION_BOND:int:1000000000000000}
+      realitio_answer_question_bounty: ${REALITIO_ANSWER_QUESTION_BOUNTY:int:0}
       questions_to_close_batch_size: ${QUESTIONS_TO_CLOSE_BATCH_SIZE:int:1}
       tendermint_url: ${TENDERMINT_URL:str:http://localhost:26657}
       tendermint_p2p_url: ${TENDERMINT_P2P_URL:str:localhost:26656}

--- a/packages/valory/skills/market_creation_manager_abci/behaviours.py
+++ b/packages/valory/skills/market_creation_manager_abci/behaviours.py
@@ -2369,7 +2369,7 @@ class GetPendingQuestionsBehaviour(MarketCreationManagerBaseBehaviour):
         max_num_questions = min(
             len(eligible_questions_id), self.params.questions_to_close_batch_size
         )
-        bond_required = self.params.close_question_bond * max_num_questions
+        bond_required = self.params.realitio_answer_question_bond * max_num_questions
 
         # TODO uncomment
         if balance < bond_required:
@@ -2561,7 +2561,7 @@ class AnswerQuestionsBehaviour(MarketCreationManagerBaseBehaviour):
         data = cast(bytes, response.state.body["data"])
         return {
             "to": self.params.realitio_contract,
-            "value": self.params.close_question_bond,
+            "value": self.params.realitio_answer_question_bond,
             "data": data,
         }
 

--- a/packages/valory/skills/market_creation_manager_abci/behaviours.py
+++ b/packages/valory/skills/market_creation_manager_abci/behaviours.py
@@ -1932,7 +1932,7 @@ class PrepareTransactionBehaviour(MarketCreationManagerBaseBehaviour):
         return {
             "to": self.params.realitio_contract,
             "data": response.state.body["data"],
-            "value": ETHER_VALUE,
+            "value": self.params.realitio_answer_question_bounty,
         }
 
     def _prepare_prepare_condition_mstx(

--- a/packages/valory/skills/market_creation_manager_abci/models.py
+++ b/packages/valory/skills/market_creation_manager_abci/models.py
@@ -94,8 +94,8 @@ class MarketCreationManagerParams(BaseParams):
         self.questions_to_close_batch_size = self._ensure(
             "questions_to_close_batch_size", kwargs, type_=int
         )
-        self.close_question_bond = self._ensure(
-            "close_question_bond", kwargs, type_=int
+        self.realitio_answer_question_bond = self._ensure(
+            "realitio_answer_question_bond", kwargs, type_=int
         )
         self.min_approve_markets_epoch_seconds = self._ensure(
             "min_approve_markets_epoch_seconds", kwargs, type_=int

--- a/packages/valory/skills/market_creation_manager_abci/models.py
+++ b/packages/valory/skills/market_creation_manager_abci/models.py
@@ -97,6 +97,9 @@ class MarketCreationManagerParams(BaseParams):
         self.realitio_answer_question_bond = self._ensure(
             "realitio_answer_question_bond", kwargs, type_=int
         )
+        self.realitio_answer_question_bounty = self._ensure(
+            "realitio_answer_question_bounty", kwargs, type_=int
+        )
         self.min_approve_markets_epoch_seconds = self._ensure(
             "min_approve_markets_epoch_seconds", kwargs, type_=int
         )

--- a/packages/valory/skills/market_creation_manager_abci/skill.yaml
+++ b/packages/valory/skills/market_creation_manager_abci/skill.yaml
@@ -205,7 +205,7 @@ models:
       tendermint_p2p_url: localhost:26656
       tendermint_url: http://localhost:26657
       tx_timeout: 10.0
-      close_question_bond: 1000000000000000
+      realitio_answer_question_bond: 1000000000000000
       questions_to_close_batch_size: 1
       validate_timeout: 1205
       use_termination: false

--- a/packages/valory/skills/market_creation_manager_abci/skill.yaml
+++ b/packages/valory/skills/market_creation_manager_abci/skill.yaml
@@ -10,11 +10,11 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   .gitignore: bafybeihdfdezgtr3s2lzq5y3oaitfrdy4u4pehionju2bdez35wcjgqx6y
   __init__.py: bafybeibkyjt4covc4yhd22aw7kav45zozk3exdv344emt3lilln64soaxm
-  behaviours.py: bafybeie6loksrlhrmidncajfautwsanw47nf43yavxz6kcuol3utipsa5e
+  behaviours.py: bafybeieq7lwoujmsyevbhv3vwz3d6f3ysj6a2yxq57wf4fmhzpad3vgpjm
   dialogues.py: bafybeicmaufkl7vdomnfciv7lw4536ssld7x4uemdapuhsyvfpd4ncibza
   fsm_specification.yaml: bafybeicps5t2anm7fv35fwnw7oolaxxmpmjio6mdw4sc6rzpnsolph5xlm
   handlers.py: bafybeietxjfli2i57kb7heoy772rcq2znusl36gg7jjj5g3pddw7egny3q
-  models.py: bafybeidwkm77ozr2x7qpxpvyiuerz6ih2k4bd5p25hqzzbrvhkyknwcrue
+  models.py: bafybeib6zsvkkqszeg3zhzuiirkuwxkfzniiyauwaggn7elaw33bnen2lu
   payloads.py: bafybeibu7sptf43adazxpyzwtfpph7bgfhtwiotg5sdlcwjt6iw3idqn7a
   rounds.py: bafybeie6rgwfulbu5xkuvxgrujbvenioyfggtzlmt23pbm6auzj3w4se44
   tests/__init__.py: bafybeihfxvqnyfly72tbxnnnglshcilm2kanihqnjiasvcz3ec3csw32ti
@@ -206,6 +206,7 @@ models:
       tendermint_url: http://localhost:26657
       tx_timeout: 10.0
       realitio_answer_question_bond: 1000000000000000
+      realitio_answer_question_bounty: 0
       questions_to_close_batch_size: 1
       validate_timeout: 1205
       use_termination: false

--- a/packages/valory/skills/market_maker_abci/skill.yaml
+++ b/packages/valory/skills/market_maker_abci/skill.yaml
@@ -24,7 +24,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
 - valory/registration_abci:0.1.0:bafybeieu7vq3pyns4t5ty6u3sbmpkd7yznpg3rmqifoz3jhy7pmqyg3w6q
 - valory/reset_pause_abci:0.1.0:bafybeiameewywqigpupy3u2iwnkfczeiiucue74x2l5lbge74rmw6bgaie
-- valory/market_creation_manager_abci:0.1.0:bafybeidzxfrtwdd65c5uqbcwj5csw6dnrmdcoi7lb2w4hc5rwouwtzh6ee
+- valory/market_creation_manager_abci:0.1.0:bafybeigxyy2mr2skgkthqu5qmtkrhid7dwgdn4hylhpkoeex3g6zfgua3m
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/transaction_settlement_abci:0.1.0:bafybeic3tccdjypuge2lewtlgprwkbb53lhgsgn7oiwzyrcrrptrbeyote
 - valory/mech_interact_abci:0.1.0:bafybeieryw7rk2tspyxx46loqqqimr2l5vvhtshiyg2mmdxijzb7pdoi6a
@@ -208,6 +208,7 @@ models:
       openai_api_key: openai_api_key
       xdai_threshold: 1000000000000000000
       realitio_answer_question_bond: 1000000000000000
+      realitio_answer_question_bounty: 0
       slash_threshold_amount: 10000000000000000
       light_slash_unit_amount: 5000000000000000
       serious_slash_unit_amount: 8000000000000000

--- a/packages/valory/skills/market_maker_abci/skill.yaml
+++ b/packages/valory/skills/market_maker_abci/skill.yaml
@@ -207,7 +207,7 @@ models:
       google_engine_id: google_engine_id
       openai_api_key: openai_api_key
       xdai_threshold: 1000000000000000000
-      close_question_bond: 1000000000000000
+      realitio_answer_question_bond: 1000000000000000
       slash_threshold_amount: 10000000000000000
       light_slash_unit_amount: 5000000000000000
       serious_slash_unit_amount: 8000000000000000


### PR DESCRIPTION
Add reality.eth answer question bounty. A configurable parameter has been added to add a bounty (reward) for answering a question.

Following reality.eth description:

> The reward encourages others to answer the question. The final answer claims the reward. (You can also leave the reward as zero if you plan to supply the answer yourself, assuming it will survive challenges.)


