### PR TITLE
Move to Kleros arbirtator with smaller fee (0.6 ETH) and possibility of appeals

### DIFF
--- a/packages/valory/agents/market_maker/aea-config.yaml
+++ b/packages/valory/agents/market_maker/aea-config.yaml
@@ -181,7 +181,7 @@ models:
       conditional_tokens_contract: ${str:0xCeAfDD6bc0bEF976fdCd1112955828E00543c0Ce}
       fpmm_deterministic_factory_contract: ${str:0x9083A2B699c0a4AD06F63580BDE2635d26a3eeF0}
       collateral_tokens_contract: ${str:0xe91d153e0b41518a2ce8dd3d7944fa863463a97d}
-      arbitrator_contract: ${str:0xe40dd83a262da3f56976038f1554fe541fa75ecd}
+      arbitrator_contract: ${str:0x29f39de98d750eb77b5fafb31b2837f079fce222}
       multisend_address: ${str:0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761}
       multisend_batch_size: ${int:5}
       ipfs_address: ${str:https://gateway.autonolas.tech/ipfs/}

--- a/packages/valory/services/market_maker/service.yaml
+++ b/packages/valory/services/market_maker/service.yaml
@@ -65,7 +65,7 @@ models:
       conditional_tokens_contract: ${CONDITIONAL_TOKENS_CONTRACT:str:0xCeAfDD6bc0bEF976fdCd1112955828E00543c0Ce}
       fpmm_deterministic_factory_contract: ${FPMM_DETERMINISTIC_FACTORY_CONTRACT:str:0x9083A2B699c0a4AD06F63580BDE2635d26a3eeF0}
       collateral_tokens_contract: ${COLLATERAL_TOKENS_CONTRACT:str:0xe91d153e0b41518a2ce8dd3d7944fa863463a97d}
-      arbitrator_contract: ${ARBITRATOR_CONTRACT:str:0xe40dd83a262da3f56976038f1554fe541fa75ecd}
+      arbitrator_contract: ${ARBITRATOR_CONTRACT:str:0x29f39de98d750eb77b5fafb31b2837f079fce222}
       multisend_address: ${MULTISEND_ADDRESS:str:0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761}
       multisend_batch_size: ${MULTISEND_BATCH_SIZE:int:1}
       ipfs_address: ${IPFS_ADDRESS:str:https://gateway.autonolas.tech/ipfs/}


### PR DESCRIPTION
See https://github.com/gnosis/prediction-market-agent-tooling/issues/444 for more details.

To sum it up, the current arbitrator cost is 10 ETH because it will spawn 511 jurors, and there is no possibility of appeals.

On gnosis-ai channel on Discord, an issue was raised that no one is going to pay such a huge fee for our low-liquidity markets and it makes people worried that they won't be able to afford the arbitration, if someone richer is going to challenge them. Which also happened yesterday:  **https://t.me/kleros/180186**

This PR changes the arbitrator to the one that costs 0.6 ETH, it spawns 31 jurors at the beginning, but appeal is possible.