### PR TITLE
Use Kleros' new arbitrator contract

### DIFF
--- a/packages/valory/agents/market_maker/aea-config.yaml
+++ b/packages/valory/agents/market_maker/aea-config.yaml
@@ -186,7 +186,7 @@ models:
       conditional_tokens_contract: ${str:0xCeAfDD6bc0bEF976fdCd1112955828E00543c0Ce}
       fpmm_deterministic_factory_contract: ${str:0x9083A2B699c0a4AD06F63580BDE2635d26a3eeF0}
       collateral_tokens_contract: ${str:0xe91d153e0b41518a2ce8dd3d7944fa863463a97d}
-      arbitrator_contract: ${str:0x29f39de98d750eb77b5fafb31b2837f079fce222}
+      arbitrator_contract: ${str:0x5562Ac605764DC4039fb6aB56a74f7321396Cdf2}
       multisend_address: ${str:0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761}
       multisend_batch_size: ${int:5}
       ipfs_address: ${str:https://gateway.autonolas.tech/ipfs/}

--- a/packages/valory/services/market_maker/service.yaml
+++ b/packages/valory/services/market_maker/service.yaml
@@ -66,7 +66,7 @@ models:
       conditional_tokens_contract: ${CONDITIONAL_TOKENS_CONTRACT:str:0xCeAfDD6bc0bEF976fdCd1112955828E00543c0Ce}
       fpmm_deterministic_factory_contract: ${FPMM_DETERMINISTIC_FACTORY_CONTRACT:str:0x9083A2B699c0a4AD06F63580BDE2635d26a3eeF0}
       collateral_tokens_contract: ${COLLATERAL_TOKENS_CONTRACT:str:0xe91d153e0b41518a2ce8dd3d7944fa863463a97d}
-      arbitrator_contract: ${ARBITRATOR_CONTRACT:str:0x29f39de98d750eb77b5fafb31b2837f079fce222}
+      arbitrator_contract: ${ARBITRATOR_CONTRACT:str:0x5562Ac605764DC4039fb6aB56a74f7321396Cdf2}
       multisend_address: ${MULTISEND_ADDRESS:str:0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761}
       multisend_batch_size: ${MULTISEND_BATCH_SIZE:int:1}
       ipfs_address: ${IPFS_ADDRESS:str:https://gateway.autonolas.tech/ipfs/}


### PR DESCRIPTION
In [this PR](https://github.com/valory-xyz/market-creator/pull/120) we switched to ` Kleros arbirtator with smaller fee (0.6 ETH) `, which is great, however Kleros found out they have some problems with that contract. 

They fixed it in our code[ in this PR](https://github.com/gnosis/prediction-market-agent-tooling/pull/550), so I'm just replicating it here 🙏 