### PR TITLE
ci: add 'All checks passed' aggregate gate job

### DIFF
--- a/.github/workflows/common_checks.yml
+++ b/.github/workflows/common_checks.yml
@@ -232,3 +232,22 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
+
+  all_checks_passed:
+    name: All checks passed
+    if: always()
+    needs:
+      - lock_check
+      - copyright_and_dependencies_check
+      - linter_checks
+      - scan
+      - test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Fail if any dependency failed or was cancelled
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required jobs succeeded."


### PR DESCRIPTION
## Summary
- Adds a single `all_checks_passed` meta job to `common_checks.yml` that depends on every mandatory job (`lock_check`, `copyright_and_dependencies_check`, `linter_checks`, `scan`, `test`).
- Uses `if: always()` and fails the job when any dependency reports `failure` or `cancelled`, giving branch protection one stable context to gate on.
- Required before wiring `All checks passed` into the `main` branch required status checks per our default repo settings.

## Test plan
- [ ] CI runs the new `All checks passed` job on this PR and it turns green once all deps succeed.
- [ ] Verify the job fails deterministically if any upstream job is forced to fail (can be spot-checked later by intentionally breaking a lint step on a throwaway branch).
- [ ] After merge, update branch protection on `main` to require the `All checks passed` context with `strict: true`.

Follow-up: update `needs:` list whenever a mandatory job is added or removed, instead of editing branch protection.

Generated with [Claude Code](https://claude.com/claude-code)
