### PR TITLE
chore(deps): drop pip>=24.0 from runtime deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
     "py-multicodec==0.2.1",
     "eth-utils==5.3.0",
     "setuptools>=78.0.1,<79",
-    "pip>=24.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -2049,7 +2049,6 @@ dependencies = [
     { name = "openapi-core" },
     { name = "openapi-spec-validator" },
     { name = "packaging" },
-    { name = "pip" },
     { name = "protobuf" },
     { name = "py-eth-sig-utils" },
     { name = "py-multibase" },
@@ -2097,7 +2096,6 @@ requires-dist = [
     { name = "openapi-core", specifier = "==0.22.0" },
     { name = "openapi-spec-validator", specifier = ">=0.7.0,<0.8.0" },
     { name = "packaging", specifier = "==26" },
-    { name = "pip", specifier = ">=24.0" },
     { name = "protobuf", specifier = ">=5,<6" },
     { name = "py-eth-sig-utils", specifier = "==0.4.0" },
     { name = "py-multibase", specifier = "==1.0.3" },
@@ -2763,15 +2761,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/67/93/8f2c2075b180c12c1e9f6a09d1a985bc2036906b13dff1d8917e395f2048/pathable-0.4.4.tar.gz", hash = "sha256:6905a3cd17804edfac7875b5f6c9142a218c7caef78693c2dbbbfbac186d88b2", size = 8124, upload-time = "2025-01-10T18:43:13.247Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/eb/b6260b31b1a96386c0a880edebe26f89669098acea8e0318bff6adb378fd/pathable-0.4.4-py3-none-any.whl", hash = "sha256:5ae9e94793b6ef5a4cbe0a7ce9dbbefc1eec38df253763fd0aeeacf2762dbbc2", size = 9592, upload-time = "2025-01-10T18:43:11.88Z" },
-]
-
-[[package]]
-name = "pip"
-version = "26.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Pip is a build/install tool and shouldn't be in the app's runtime dependency list. Mirrors the cleanup done in meme-ooorr commit `11acfdad1` per #436 rule.

`uv lock` removed the corresponding entry from `uv.lock`. No `tox.ini` change (the tox-internal `pip` in liccheck/freeze envs is a separate dep). No `autonomy packages lock` change — package hashes are unaffected.

## Test plan

- [ ] CI green (check-dependencies, tests, liccheck)
- [ ] `uv sync` produces a working venv
- [ ] `autonomy --version` still works (sanity check for the jmoreira bug from market-resolver `aabf26b2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)