### PR TITLE
fix(config): revert named runtime setup params on market_maker aea-config

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -3,8 +3,8 @@
         "contract/valory/fpmm_deterministic_factory/0.1.0": "bafybeiazddwzm6dc6625dkynx4devvfy5rq3fbh3vrpj4h66r7lusj6vua",
         "skill/valory/market_creation_manager_abci/0.1.0": "bafybeih33cswnqzlqtqf3hafcvipj3jappc7heobxox6ie4xgou73wx7yq",
         "skill/valory/market_maker_abci/0.1.0": "bafybeiawxosgijccnhlzpgd225vln6ntcerpkm4pdwlzxnsuv2jzhukcla",
-        "agent/valory/market_maker/0.1.0": "bafybeial2i2jboq6fdw7sq4dmdvrqck6pbocjt6xb5k7dzhemkaxjzhw44",
-        "service/valory/market_maker/0.1.0": "bafybeieukjhjgaptcpqnoatup72wm7fo7hct7bto26nr6ug3ynp7k3kzuy"
+        "agent/valory/market_maker/0.1.0": "bafybeifsn4o4gupgfc52qcza6arge5uhpsoiqethafpegxtw5r333buokq",
+        "service/valory/market_maker/0.1.0": "bafybeibeum27eb4zlfi5mopyt6a4psklzia45siigzxurdker2tywe3o7a"
     },
     "third_party": {
         "protocol/valory/contract_api/1.0.0": "bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la",

--- a/packages/valory/agents/market_maker/aea-config.yaml
+++ b/packages/valory/agents/market_maker/aea-config.yaml
@@ -177,9 +177,9 @@ models:
       service_id: ${SERVICE_ID:str:market_maker}
       service_registry_address: ${SERVICE_REGISTRY_ADDRESS:str:0x9338b5153AE39BB89f50468E608eD9d764B755fD}
       setup:
-        all_participants: ${ALL_PARTICIPANTS:list:["0x0000000000000000000000000000000000000000"]}
-        safe_contract_address: ${SAFE_CONTRACT_ADDRESS:str:0x0000000000000000000000000000000000000000}
-        consensus_threshold: ${CONSENSUS_THRESHOLD:int:null}
+        all_participants: ${list:["0x0000000000000000000000000000000000000000"]}
+        safe_contract_address: ${str:0x0000000000000000000000000000000000000000}
+        consensus_threshold: ${int:null}
       share_tm_config_on_startup: ${SHARE_TM_CONFIG_ON_STARTUP:bool:false}
       tendermint_check_sleep_delay: ${TENDERMINT_CHECK_SLEEP_DELAY:int:3}
       tendermint_com_url: ${TENDERMINT_COM_URL:str:http://localhost:8080}

--- a/packages/valory/services/market_maker/service.yaml
+++ b/packages/valory/services/market_maker/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibwz3af6326msp4h3kqehijvmyhaytvyfbo3o2npc2w4b6zrg6pfq
 fingerprint_ignore_patterns: []
-agent: valory/market_maker:0.1.0:bafybeial2i2jboq6fdw7sq4dmdvrqck6pbocjt6xb5k7dzhemkaxjzhw44
+agent: valory/market_maker:0.1.0:bafybeifsn4o4gupgfc52qcza6arge5uhpsoiqethafpegxtw5r333buokq
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Summary

Reverts the three agent setup-block runtime params named by #217 back to the anonymous form. They are runtime/consensus values that the deployment computes and injects — naming them breaks Pearl/`autonomy deploy` consensus.

```diff
-        all_participants: ${ALL_PARTICIPANTS:list:["0x0000000000000000000000000000000000000000"]}
-        safe_contract_address: ${SAFE_CONTRACT_ADDRESS:str:0x0000000000000000000000000000000000000000}
-        consensus_threshold: ${CONSENSUS_THRESHOLD:int:null}
+        all_participants: ${list:["0x0000000000000000000000000000000000000000"]}
+        safe_contract_address: ${str:0x0000000000000000000000000000000000000000}
+        consensus_threshold: ${int:null}
```

## Root cause

`ServiceBuilder.try_update_runtime_params` (`open-autonomy/autonomy/deploy/base.py`, and Pearl's middleware override) overwrites `safe_contract_address`, `all_participants` and `consensus_threshold` in the service overrides with the literal runtime-computed values **before** open-autonomy's `_extract_named_env_var_defaults` runs. Once the template string is replaced by a literal, there is no `${NAME:...}` placeholder left for the extractor to find, so no named key (`ALL_PARTICIPANTS`, `SAFE_CONTRACT_ADDRESS`, `CONSENSUS_THRESHOLD`) lands in `agent.json`.

open-aea then ignores the path-based fallback key (`SKILL_..._SETUP_*`) because the agent template is in named form, so the agent falls back to the zero-address / null YAML defaults in `aea-config.yaml`, and the consensus round rejects the real agent (`TransactionNotValidError: ... not in list of participants: ['0x0000...0000']`).

This is the same class of bug that optimus fixed in valory-xyz/optimus#330 (which reverted `all_participants`). market-creator named all three of these runtime setup fields, so all three are reverted here. `service.yaml` keeps the named form — it is unaffected, since `try_update_runtime_params` rewrites it anyway and the path-based key is what reaches the agent.

The durable fix lives in olas-operate-middleware / open-autonomy: teach `try_update_runtime_params` (or the extraction step) to also push the resolved value as a named key when it rewrites the override. Once that lands, these can return to the named form.

## Test plan

- [x] `tomte tox -e check-hash`, `check-packages`, `check-third-party-hashes`
- [x] `tomte tox -e check-dependencies`, `liccheck`, `check-doc-hashes`
- [x] `tomte tox -e check-abciapp-specs`, `check-abci-docstrings`, `check-handlers`, `analyse-service`
- [x] `tomte tox -p -e black-check -e isort-check -e flake8 -e mypy -e pylint -e darglint`
- [x] `tomte tox -p -e safety -e bandit`, `gitleaks`
- [x] `tomte tox -e py3.11-darwin` — 308 passed
- [x] `uv lock --check`, `uv sync --all-groups`
- [ ] Pearl / `autonomy deploy` smoke test: confirm `TransactionNotValidError` is gone and consensus proceeds with the real agent address

🤖 Generated with [Claude Code](https://claude.com/claude-code)
