### PR TITLE
fix(healthcheck): report is_healthy=false when FSM is frozen (mech parity)

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,9 +2,9 @@
     "dev": {
         "contract/valory/fpmm_deterministic_factory/0.1.0": "bafybeiazddwzm6dc6625dkynx4devvfy5rq3fbh3vrpj4h66r7lusj6vua",
         "skill/valory/market_creation_manager_abci/0.1.0": "bafybeigszoicm2gin6znvcz32ve5v6s4qp3bp3jdgjumnsgmf7ymcn52km",
-        "skill/valory/market_maker_abci/0.1.0": "bafybeicsgyhshjcufo764uyya224oselzrvehhmfpkkjyqunmncbtxnsma",
-        "agent/valory/market_maker/0.1.0": "bafybeig7gmchm2eope2khscrwpaq5zn56pubrpzubdzy2wcfhyuon53j44",
-        "service/valory/market_maker/0.1.0": "bafybeiawxoftppi46jvd3j5czj4bv6ejuf3xfhyk6rdcz7eydpn2n5te74"
+        "skill/valory/market_maker_abci/0.1.0": "bafybeic4q64ibaenngwnlwjxmjw7hzvc6w4wlvhmlrf2qtbiybnvhfefuq",
+        "agent/valory/market_maker/0.1.0": "bafybeidkn6yrsebfrykqoqvgxj4ra2r3v4v26rqinhxrav7dxu42ns3x3a",
+        "service/valory/market_maker/0.1.0": "bafybeiclm3bt2q7h4xva3b42shlmcyn6iu3zneqf2vczxhtczhn62ngjmi"
     },
     "third_party": {
         "protocol/valory/contract_api/1.0.0": "bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,9 +2,9 @@
     "dev": {
         "contract/valory/fpmm_deterministic_factory/0.1.0": "bafybeiazddwzm6dc6625dkynx4devvfy5rq3fbh3vrpj4h66r7lusj6vua",
         "skill/valory/market_creation_manager_abci/0.1.0": "bafybeigszoicm2gin6znvcz32ve5v6s4qp3bp3jdgjumnsgmf7ymcn52km",
-        "skill/valory/market_maker_abci/0.1.0": "bafybeig7bf7nhr3rku75g2dcmjjin3hyzcvv2ki3xgt3pbspt5a5qcvfeu",
-        "agent/valory/market_maker/0.1.0": "bafybeiga2p37rirbnn3eqoxab5iuvq4jpwwauyw6h3jcc3ktuwjjuveiy4",
-        "service/valory/market_maker/0.1.0": "bafybeicsonqp2lbn2suo3msc3pxwrwpchc4bw5lmpxs4slkryfjcxzs7ci"
+        "skill/valory/market_maker_abci/0.1.0": "bafybeif777qp6iyyyddgsrrhukveezw36e4inipab7rfjjwtdkujciealu",
+        "agent/valory/market_maker/0.1.0": "bafybeie5f64ecregr3rcpktqc67xtzxooxtoigsymok7hntgt4c34crjpi",
+        "service/valory/market_maker/0.1.0": "bafybeigpamwpfjwvrrzizb62paox6jhhngm2hr2mpivty6fhzdupprhiva"
     },
     "third_party": {
         "protocol/valory/contract_api/1.0.0": "bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,9 +2,9 @@
     "dev": {
         "contract/valory/fpmm_deterministic_factory/0.1.0": "bafybeiazddwzm6dc6625dkynx4devvfy5rq3fbh3vrpj4h66r7lusj6vua",
         "skill/valory/market_creation_manager_abci/0.1.0": "bafybeigszoicm2gin6znvcz32ve5v6s4qp3bp3jdgjumnsgmf7ymcn52km",
-        "skill/valory/market_maker_abci/0.1.0": "bafybeif777qp6iyyyddgsrrhukveezw36e4inipab7rfjjwtdkujciealu",
-        "agent/valory/market_maker/0.1.0": "bafybeie5f64ecregr3rcpktqc67xtzxooxtoigsymok7hntgt4c34crjpi",
-        "service/valory/market_maker/0.1.0": "bafybeigpamwpfjwvrrzizb62paox6jhhngm2hr2mpivty6fhzdupprhiva"
+        "skill/valory/market_maker_abci/0.1.0": "bafybeicsgyhshjcufo764uyya224oselzrvehhmfpkkjyqunmncbtxnsma",
+        "agent/valory/market_maker/0.1.0": "bafybeig7gmchm2eope2khscrwpaq5zn56pubrpzubdzy2wcfhyuon53j44",
+        "service/valory/market_maker/0.1.0": "bafybeiawxoftppi46jvd3j5czj4bv6ejuf3xfhyk6rdcz7eydpn2n5te74"
     },
     "third_party": {
         "protocol/valory/contract_api/1.0.0": "bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la",

--- a/packages/valory/agents/market_maker/aea-config.yaml
+++ b/packages/valory/agents/market_maker/aea-config.yaml
@@ -42,7 +42,7 @@ skills:
 - valory/funds_forwarder_abci:0.1.0:bafybeihuxw5tgnp4hie76as2jwnbp5abxrkmlmmpu4ila6ey34xrfkqqie
 - valory/identify_service_owner_abci:0.1.0:bafybeid7qw3aoorbv2bnxwd54npkgvdxf6kzpfscnmzqiui74jiskjmitm
 - valory/market_creation_manager_abci:0.1.0:bafybeigszoicm2gin6znvcz32ve5v6s4qp3bp3jdgjumnsgmf7ymcn52km
-- valory/market_maker_abci:0.1.0:bafybeif777qp6iyyyddgsrrhukveezw36e4inipab7rfjjwtdkujciealu
+- valory/market_maker_abci:0.1.0:bafybeicsgyhshjcufo764uyya224oselzrvehhmfpkkjyqunmncbtxnsma
 - valory/omen_ct_redeem_tokens_abci:0.1.0:bafybeif6w2bplgceactukt5b6qpth5nxspdeljsxaywrlyxvymdxxiefsq
 - valory/omen_fpmm_remove_liquidity_abci:0.1.0:bafybeibuldgtifqjst4oeremvl6huzvdnq36opgwv2wupsnplf4er5frpm
 - valory/omen_realitio_withdraw_bonds_abci:0.1.0:bafybeicj3pgdx7q5chbms3pxrb6pcv7lbqhkigwnmjuo54p63ub7mkqe5i

--- a/packages/valory/agents/market_maker/aea-config.yaml
+++ b/packages/valory/agents/market_maker/aea-config.yaml
@@ -42,7 +42,7 @@ skills:
 - valory/funds_forwarder_abci:0.1.0:bafybeihuxw5tgnp4hie76as2jwnbp5abxrkmlmmpu4ila6ey34xrfkqqie
 - valory/identify_service_owner_abci:0.1.0:bafybeid7qw3aoorbv2bnxwd54npkgvdxf6kzpfscnmzqiui74jiskjmitm
 - valory/market_creation_manager_abci:0.1.0:bafybeigszoicm2gin6znvcz32ve5v6s4qp3bp3jdgjumnsgmf7ymcn52km
-- valory/market_maker_abci:0.1.0:bafybeicsgyhshjcufo764uyya224oselzrvehhmfpkkjyqunmncbtxnsma
+- valory/market_maker_abci:0.1.0:bafybeic4q64ibaenngwnlwjxmjw7hzvc6w4wlvhmlrf2qtbiybnvhfefuq
 - valory/omen_ct_redeem_tokens_abci:0.1.0:bafybeif6w2bplgceactukt5b6qpth5nxspdeljsxaywrlyxvymdxxiefsq
 - valory/omen_fpmm_remove_liquidity_abci:0.1.0:bafybeibuldgtifqjst4oeremvl6huzvdnq36opgwv2wupsnplf4er5frpm
 - valory/omen_realitio_withdraw_bonds_abci:0.1.0:bafybeicj3pgdx7q5chbms3pxrb6pcv7lbqhkigwnmjuo54p63ub7mkqe5i

--- a/packages/valory/agents/market_maker/aea-config.yaml
+++ b/packages/valory/agents/market_maker/aea-config.yaml
@@ -42,7 +42,7 @@ skills:
 - valory/funds_forwarder_abci:0.1.0:bafybeihuxw5tgnp4hie76as2jwnbp5abxrkmlmmpu4ila6ey34xrfkqqie
 - valory/identify_service_owner_abci:0.1.0:bafybeid7qw3aoorbv2bnxwd54npkgvdxf6kzpfscnmzqiui74jiskjmitm
 - valory/market_creation_manager_abci:0.1.0:bafybeigszoicm2gin6znvcz32ve5v6s4qp3bp3jdgjumnsgmf7ymcn52km
-- valory/market_maker_abci:0.1.0:bafybeig7bf7nhr3rku75g2dcmjjin3hyzcvv2ki3xgt3pbspt5a5qcvfeu
+- valory/market_maker_abci:0.1.0:bafybeif777qp6iyyyddgsrrhukveezw36e4inipab7rfjjwtdkujciealu
 - valory/omen_ct_redeem_tokens_abci:0.1.0:bafybeif6w2bplgceactukt5b6qpth5nxspdeljsxaywrlyxvymdxxiefsq
 - valory/omen_fpmm_remove_liquidity_abci:0.1.0:bafybeibuldgtifqjst4oeremvl6huzvdnq36opgwv2wupsnplf4er5frpm
 - valory/omen_realitio_withdraw_bonds_abci:0.1.0:bafybeicj3pgdx7q5chbms3pxrb6pcv7lbqhkigwnmjuo54p63ub7mkqe5i

--- a/packages/valory/services/market_maker/service.yaml
+++ b/packages/valory/services/market_maker/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibwz3af6326msp4h3kqehijvmyhaytvyfbo3o2npc2w4b6zrg6pfq
 fingerprint_ignore_patterns: []
-agent: valory/market_maker:0.1.0:bafybeig7gmchm2eope2khscrwpaq5zn56pubrpzubdzy2wcfhyuon53j44
+agent: valory/market_maker:0.1.0:bafybeidkn6yrsebfrykqoqvgxj4ra2r3v4v26rqinhxrav7dxu42ns3x3a
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/market_maker/service.yaml
+++ b/packages/valory/services/market_maker/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibwz3af6326msp4h3kqehijvmyhaytvyfbo3o2npc2w4b6zrg6pfq
 fingerprint_ignore_patterns: []
-agent: valory/market_maker:0.1.0:bafybeiga2p37rirbnn3eqoxab5iuvq4jpwwauyw6h3jcc3ktuwjjuveiy4
+agent: valory/market_maker:0.1.0:bafybeie5f64ecregr3rcpktqc67xtzxooxtoigsymok7hntgt4c34crjpi
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/market_maker/service.yaml
+++ b/packages/valory/services/market_maker/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibwz3af6326msp4h3kqehijvmyhaytvyfbo3o2npc2w4b6zrg6pfq
 fingerprint_ignore_patterns: []
-agent: valory/market_maker:0.1.0:bafybeie5f64ecregr3rcpktqc67xtzxooxtoigsymok7hntgt4c34crjpi
+agent: valory/market_maker:0.1.0:bafybeig7gmchm2eope2khscrwpaq5zn56pubrpzubdzy2wcfhyuon53j44
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/market_maker_abci/handlers.py
+++ b/packages/valory/skills/market_maker_abci/handlers.py
@@ -17,7 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 
-"""This module contains the handler for the 'price_estimation_abci' skill."""
+"""This module contains the handler for the 'market_maker_abci' skill."""
 
 import json
 import re
@@ -70,7 +70,6 @@ IpfsHandler = BaseIpfsHandler
 # Health thresholds (mirrored from the mech service for cross-service parity).
 LIVENESS_STALL_FACTOR = 3.0  # > 3x the expected pause means the FSM is "stuck"
 TRANSITION_TOLERANCE_FACTOR = 2.0  # < 2x the expected pause means "transitioning fast"
-DEFAULT_GRACE = 120.0  # readiness/progress grace floor, kept for mech parity
 HEALTH_VERSION = 2
 
 

--- a/packages/valory/skills/market_maker_abci/handlers.py
+++ b/packages/valory/skills/market_maker_abci/handlers.py
@@ -69,7 +69,9 @@ IpfsHandler = BaseIpfsHandler
 
 # Health thresholds (mirrored from the mech service for cross-service parity).
 LIVENESS_STALL_FACTOR = 3.0  # > 3x the expected pause means the FSM is "stuck"
-TRANSITION_TOLERANCE_FACTOR = 2.0  # < 2x the expected pause means "transitioning fast"
+TRANSITION_TOLERANCE_FACTOR = (
+    2.0  # < 2x the expected pause (and tm healthy) means "transitioning fast"
+)
 HEALTH_VERSION = 2
 
 
@@ -264,18 +266,16 @@ class HttpHandler(BaseHttpHandler):
         """
         Handle GET /healthcheck and compute the agent's health metrics.
 
-        The health is assessed across three dimensions (mech-service parity):
+        Only **liveness** is actually measured: whether the FSM is transitioning
+        and Tendermint is not stalled. A missing last-transition timestamp is
+        reported as not-live (reason ``no-fsm-data``) so a frozen FSM cannot
+        read as healthy. ``readiness`` and ``progress`` are always-ok
+        placeholders kept for shape parity with the mech service -- market-creator
+        is FSM-only with no task backlog or dependency-read metric.
 
-        - **Liveness**: whether the FSM is actively transitioning and Tendermint
-          is not in a stalled state. This is the dimension that catches a frozen
-          FSM: a missing last-transition timestamp is reported as not-live
-          (reason ``no-fsm-data``) instead of being silently treated as healthy.
-        - **Readiness**: whether the agent can accept new work.
-        - **Progress**: whether the agent is advancing through its backlog.
-
-        market-creator is an FSM-only service with no task backlog or dependency
-        read metric (unlike mech), so readiness and progress are always-ok
-        placeholders (reason ``idle-ok``) kept for shape parity with mech.
+        TODO: if this service later gains external I/O that can stall a
+        behaviour while the FSM still ticks via timeout transitions, compute
+        readiness/progress for real instead of these placeholders.
 
         The endpoint always responds with HTTP 200; a wedge is signalled solely
         via ``is_healthy: false`` in the JSON body.
@@ -288,46 +288,49 @@ class HttpHandler(BaseHttpHandler):
         is_transitioning_fast: Optional[bool] = None
         current_round: Optional[str] = None
         rounds: Optional[List[str]] = None
+        period: Optional[int] = None
 
         round_sequence = cast(SharedState, self.context.state).round_sequence
         reset_pause = float(self.context.params.reset_pause_duration)
 
         # Guard A: FSM liveness data is only available once we have transitioned.
-        if round_sequence._last_round_transition_timestamp:
-            is_tm_unhealthy = cast(
-                SharedState, self.context.state
-            ).round_sequence.block_stall_deadline_expired
-
+        if round_sequence._last_round_transition_timestamp is not None:
+            is_tm_unhealthy = round_sequence.block_stall_deadline_expired
             current_time = datetime.now().timestamp()
             seconds_since_last_transition = current_time - datetime.timestamp(
                 round_sequence._last_round_transition_timestamp
             )
-
             is_transitioning_fast = (not is_tm_unhealthy) and (
                 seconds_since_last_transition
                 < TRANSITION_TOLERANCE_FACTOR * reset_pause
             )
 
-        # Guard B: round identifiers for observability.
+        # Guard B: round identifiers + period require an initialised AbciApp.
+        # Reading synchronized_data before that raises ABCIAppInternalError, so
+        # keep it guarded to honour the always-HTTP-200 contract at boot.
         if round_sequence._abci_app:
             current_round = round_sequence._abci_app.current_round.round_id
             rounds = [
                 r.round_id for r in round_sequence._abci_app._previous_rounds[-25:]
             ]
             rounds.append(current_round)
+            period = self.synchronized_data.period_count
 
-        # Liveness: catches the wedge. No FSM data or unknown tm state -> not live.
-        if seconds_since_last_transition is None or is_tm_unhealthy is None:
+        # Liveness catches a frozen FSM. seconds_since_last_transition and
+        # is_tm_unhealthy are set together in Guard A, so a None timestamp is
+        # the single "no transition yet" trigger.
+        if seconds_since_last_transition is None:
             liveness_ok, live_reason = False, "no-fsm-data"
         else:
             liveness_ok = (not is_tm_unhealthy) and (
                 seconds_since_last_transition <= LIVENESS_STALL_FACTOR * reset_pause
             )
-            live_reason = (
-                "ok"
-                if liveness_ok
-                else ("tm-unhealthy" if is_tm_unhealthy else "stuck-no-transition")
-            )
+            if liveness_ok:
+                live_reason = "ok"
+            elif is_tm_unhealthy:
+                live_reason = "tm-unhealthy"
+            else:
+                live_reason = "stuck-no-transition"
 
         # Readiness/progress: market-creator has no backlog metric, so these are
         # always-ok placeholders kept for mech parity.
@@ -344,7 +347,7 @@ class HttpHandler(BaseHttpHandler):
             "seconds_since_last_transition": seconds_since_last_transition,
             # Three-state: True (healthy), False (unhealthy), None (unknown).
             "is_tm_healthy": (None if is_tm_unhealthy is None else not is_tm_unhealthy),
-            "period": self.synchronized_data.period_count,
+            "period": period,
             "reset_pause_duration": reset_pause,
             "current_round": current_round,
             "rounds": rounds,

--- a/packages/valory/skills/market_maker_abci/handlers.py
+++ b/packages/valory/skills/market_maker_abci/handlers.py
@@ -67,6 +67,12 @@ ContractApiHandler = BaseContractApiHandler
 TendermintHandler = BaseTendermintHandler
 IpfsHandler = BaseIpfsHandler
 
+# Health thresholds (mirrored from the mech service for cross-service parity).
+LIVENESS_STALL_FACTOR = 3.0  # > 3x the expected pause means the FSM is "stuck"
+TRANSITION_TOLERANCE_FACTOR = 2.0  # < 2x the expected pause means "transitioning fast"
+DEFAULT_GRACE = 120.0  # readiness/progress grace floor, kept for mech parity
+HEALTH_VERSION = 2
+
 
 class HttpCode(Enum):
     """Http codes"""
@@ -257,19 +263,37 @@ class HttpHandler(BaseHttpHandler):
         self, http_msg: HttpMessage, http_dialogue: HttpDialogue
     ) -> None:
         """
-        Handle a Http request of verb GET.
+        Handle GET /healthcheck and compute the agent's health metrics.
+
+        The health is assessed across three dimensions (mech-service parity):
+
+        - **Liveness**: whether the FSM is actively transitioning and Tendermint
+          is not in a stalled state. This is the dimension that catches a frozen
+          FSM: a missing last-transition timestamp is reported as not-live
+          (reason ``no-fsm-data``) instead of being silently treated as healthy.
+        - **Readiness**: whether the agent can accept new work.
+        - **Progress**: whether the agent is advancing through its backlog.
+
+        market-creator is an FSM-only service with no task backlog or dependency
+        read metric (unlike mech), so readiness and progress are always-ok
+        placeholders (reason ``idle-ok``) kept for shape parity with mech.
+
+        The endpoint always responds with HTTP 200; a wedge is signalled solely
+        via ``is_healthy: false`` in the JSON body.
 
         :param http_msg: the http message
         :param http_dialogue: the http dialogue
         """
-        seconds_since_last_transition = None
-        is_tm_unhealthy = None
-        is_transitioning_fast = None
-        current_round = None
-        rounds = None
+        seconds_since_last_transition: Optional[float] = None
+        is_tm_unhealthy: Optional[bool] = None
+        is_transitioning_fast: Optional[bool] = None
+        current_round: Optional[str] = None
+        rounds: Optional[List[str]] = None
 
         round_sequence = cast(SharedState, self.context.state).round_sequence
+        reset_pause = float(self.context.params.reset_pause_duration)
 
+        # Guard A: FSM liveness data is only available once we have transitioned.
         if round_sequence._last_round_transition_timestamp:
             is_tm_unhealthy = cast(
                 SharedState, self.context.state
@@ -280,12 +304,12 @@ class HttpHandler(BaseHttpHandler):
                 round_sequence._last_round_transition_timestamp
             )
 
-            is_transitioning_fast = (
-                not is_tm_unhealthy
-                and seconds_since_last_transition
-                < 2 * self.context.params.reset_pause_duration
+            is_transitioning_fast = (not is_tm_unhealthy) and (
+                seconds_since_last_transition
+                < TRANSITION_TOLERANCE_FACTOR * reset_pause
             )
 
+        # Guard B: round identifiers for observability.
         if round_sequence._abci_app:
             current_round = round_sequence._abci_app.current_round.round_id
             rounds = [
@@ -293,13 +317,40 @@ class HttpHandler(BaseHttpHandler):
             ]
             rounds.append(current_round)
 
+        # Liveness: catches the wedge. No FSM data or unknown tm state -> not live.
+        if seconds_since_last_transition is None or is_tm_unhealthy is None:
+            liveness_ok, live_reason = False, "no-fsm-data"
+        else:
+            liveness_ok = (not is_tm_unhealthy) and (
+                seconds_since_last_transition <= LIVENESS_STALL_FACTOR * reset_pause
+            )
+            live_reason = (
+                "ok"
+                if liveness_ok
+                else ("tm-unhealthy" if is_tm_unhealthy else "stuck-no-transition")
+            )
+
+        # Readiness/progress: market-creator has no backlog metric, so these are
+        # always-ok placeholders kept for mech parity.
+        readiness_ok, ready_reason = True, "idle-ok"
+        progress_ok, prog_reason = True, "idle-ok"
+
+        is_healthy = bool(liveness_ok and readiness_ok and progress_ok)
+
         data = {
+            "is_healthy": is_healthy,
+            "liveness": {"ok": liveness_ok, "reason": live_reason},
+            "readiness": {"ok": readiness_ok, "reason": ready_reason},
+            "progress": {"ok": progress_ok, "reason": prog_reason},
             "seconds_since_last_transition": seconds_since_last_transition,
-            "is_tm_healthy": not is_tm_unhealthy,
+            # Three-state: True (healthy), False (unhealthy), None (unknown).
+            "is_tm_healthy": (None if is_tm_unhealthy is None else not is_tm_unhealthy),
             "period": self.synchronized_data.period_count,
-            "reset_pause_duration": self.context.params.reset_pause_duration,
+            "reset_pause_duration": reset_pause,
+            "current_round": current_round,
             "rounds": rounds,
             "is_transitioning_fast": is_transitioning_fast,
+            "health_version": HEALTH_VERSION,
         }
 
         self._send_ok_response(http_msg, http_dialogue, data)

--- a/packages/valory/skills/market_maker_abci/skill.yaml
+++ b/packages/valory/skills/market_maker_abci/skill.yaml
@@ -13,13 +13,13 @@ fingerprint:
   composition.py: bafybeieudii7cevqathnt2fzcx45s5r6z6sfg77b5g24xx5tl3hl6icwrm
   dialogues.py: bafybeiafgwadv6kzts6yx5gtjyuvaftnofyn3rrwvczfd5seihpydzukju
   fsm_specification.yaml: bafybeieupgiolp7q6tdsgxwmhgavv42dpaisz5ffqidwtc4jjw4vhcpuim
-  handlers.py: bafybeid6bjfkprk53b7cgmd3mp2uqr5cijlpdqjjofaylaiff7wbug22y4
+  handlers.py: bafybeih6t7gj2pjul64hfyto4jkizpfefdsex7rnv4t7ll52w6mlrc5n6u
   models.py: bafybeiesxdaoea5oiaorbl72l75ns2wr3v5vfudzib6azajylwxsagtwlq
   tests/__init__.py: bafybeibbn4ofwna62otdupfcz34fy3bgir6phq3s7q4e4cma4pfoxgeyrq
   tests/conftest.py: bafybeig6ks3pok5kcsvfetmy4f5bp5q2suxquma45bxs5cdir42rlgffyi
   tests/test_behaviours.py: bafybeiapyvud7fsne3cg2oowm2u7jni5ngixv4p3mudukisluccjzpc5l4
   tests/test_dialogues.py: bafybeiedpuwlfc24gxkjoi4wvncfnjsgc7xfqiajqmvrjdvfpfrw2bcqnm
-  tests/test_handlers.py: bafybeid5g2kd5xoa7qnitq6cobqahd5n5rspfv67ltwaqy6cpveneyn6hq
+  tests/test_handlers.py: bafybeic7g3tfvi6lmircvnquao7gkjufyhshdyivqmwzqcfin4o5ovei7a
   tests/test_models.py: bafybeihpplz5jpldwc3dwoiikpgq5pzfijgrparak25k722l6lw3ypifli
 fingerprint_ignore_patterns: []
 connections:

--- a/packages/valory/skills/market_maker_abci/skill.yaml
+++ b/packages/valory/skills/market_maker_abci/skill.yaml
@@ -13,13 +13,13 @@ fingerprint:
   composition.py: bafybeieudii7cevqathnt2fzcx45s5r6z6sfg77b5g24xx5tl3hl6icwrm
   dialogues.py: bafybeiafgwadv6kzts6yx5gtjyuvaftnofyn3rrwvczfd5seihpydzukju
   fsm_specification.yaml: bafybeieupgiolp7q6tdsgxwmhgavv42dpaisz5ffqidwtc4jjw4vhcpuim
-  handlers.py: bafybeigtgp4y3j5ihdyg5srbawraswjvvd7o2n6bzyuy46b5xdwzmxg52y
+  handlers.py: bafybeiefnf5zg2tjf6mfdaz65ath6ziditzul5u3hrkpl2h5ofwdsaw3vy
   models.py: bafybeiesxdaoea5oiaorbl72l75ns2wr3v5vfudzib6azajylwxsagtwlq
   tests/__init__.py: bafybeibbn4ofwna62otdupfcz34fy3bgir6phq3s7q4e4cma4pfoxgeyrq
   tests/conftest.py: bafybeig6ks3pok5kcsvfetmy4f5bp5q2suxquma45bxs5cdir42rlgffyi
   tests/test_behaviours.py: bafybeiapyvud7fsne3cg2oowm2u7jni5ngixv4p3mudukisluccjzpc5l4
   tests/test_dialogues.py: bafybeiedpuwlfc24gxkjoi4wvncfnjsgc7xfqiajqmvrjdvfpfrw2bcqnm
-  tests/test_handlers.py: bafybeihtl4ag7vntppcr2ltwjigptcycfz3r36droct4mbbz37cmyeidri
+  tests/test_handlers.py: bafybeia3adw5llfkkcugytry3l2xpn2tz4irecqoihyndrhessmic7o2nq
   tests/test_models.py: bafybeihpplz5jpldwc3dwoiikpgq5pzfijgrparak25k722l6lw3ypifli
 fingerprint_ignore_patterns: []
 connections:

--- a/packages/valory/skills/market_maker_abci/skill.yaml
+++ b/packages/valory/skills/market_maker_abci/skill.yaml
@@ -13,13 +13,13 @@ fingerprint:
   composition.py: bafybeieudii7cevqathnt2fzcx45s5r6z6sfg77b5g24xx5tl3hl6icwrm
   dialogues.py: bafybeiafgwadv6kzts6yx5gtjyuvaftnofyn3rrwvczfd5seihpydzukju
   fsm_specification.yaml: bafybeieupgiolp7q6tdsgxwmhgavv42dpaisz5ffqidwtc4jjw4vhcpuim
-  handlers.py: bafybeih6t7gj2pjul64hfyto4jkizpfefdsex7rnv4t7ll52w6mlrc5n6u
+  handlers.py: bafybeigtgp4y3j5ihdyg5srbawraswjvvd7o2n6bzyuy46b5xdwzmxg52y
   models.py: bafybeiesxdaoea5oiaorbl72l75ns2wr3v5vfudzib6azajylwxsagtwlq
   tests/__init__.py: bafybeibbn4ofwna62otdupfcz34fy3bgir6phq3s7q4e4cma4pfoxgeyrq
   tests/conftest.py: bafybeig6ks3pok5kcsvfetmy4f5bp5q2suxquma45bxs5cdir42rlgffyi
   tests/test_behaviours.py: bafybeiapyvud7fsne3cg2oowm2u7jni5ngixv4p3mudukisluccjzpc5l4
   tests/test_dialogues.py: bafybeiedpuwlfc24gxkjoi4wvncfnjsgc7xfqiajqmvrjdvfpfrw2bcqnm
-  tests/test_handlers.py: bafybeic7g3tfvi6lmircvnquao7gkjufyhshdyivqmwzqcfin4o5ovei7a
+  tests/test_handlers.py: bafybeihtl4ag7vntppcr2ltwjigptcycfz3r36droct4mbbz37cmyeidri
   tests/test_models.py: bafybeihpplz5jpldwc3dwoiikpgq5pzfijgrparak25k722l6lw3ypifli
 fingerprint_ignore_patterns: []
 connections:

--- a/packages/valory/skills/market_maker_abci/tests/test_handlers.py
+++ b/packages/valory/skills/market_maker_abci/tests/test_handlers.py
@@ -407,6 +407,7 @@ class TestHttpHandlerGetHealth:
         assert body["liveness"]["ok"] is True
         assert body["liveness"]["reason"] == "ok"
         assert body["is_tm_healthy"] is True
+        assert body["is_transitioning_fast"] is True
         assert isinstance(body["seconds_since_last_transition"], float)
         assert body["period"] == 10
         assert body["current_round"] == "CurrentRound"
@@ -441,6 +442,7 @@ class TestHttpHandlerGetHealth:
         assert body["liveness"]["ok"] is False
         assert body["liveness"]["reason"] == "tm-unhealthy"
         assert body["is_tm_healthy"] is False
+        assert body["is_transitioning_fast"] is False
         assert body["health_version"] == 2
 
     def test_health_stale_but_has_timestamp(self) -> None:
@@ -471,6 +473,7 @@ class TestHttpHandlerGetHealth:
         assert body["liveness"]["ok"] is False
         assert body["liveness"]["reason"] == "stuck-no-transition"
         assert body["is_tm_healthy"] is True
+        assert body["is_transitioning_fast"] is False
         assert body["seconds_since_last_transition"] > 60 * 3
         assert body["health_version"] == 2
 

--- a/packages/valory/skills/market_maker_abci/tests/test_handlers.py
+++ b/packages/valory/skills/market_maker_abci/tests/test_handlers.py
@@ -322,64 +322,75 @@ class TestHttpHandlerSendOkResponse:
 class TestHttpHandlerGetHealth:
     """Test HttpHandler._handle_get_health."""
 
-    def test_health_no_last_transition(self) -> None:
-        """Test health response when no last transition timestamp."""
+    @staticmethod
+    def _invoke_health(handler: HttpHandler) -> dict:
+        """Invoke _handle_get_health and return the decoded JSON body and status."""
+        http_msg = MagicMock()
+        http_dialogue = MagicMock()
+        http_dialogue.reply.return_value = MagicMock()
+
+        handler._handle_get_health(http_msg, http_dialogue)
+
+        http_dialogue.reply.assert_called_once()
+        call_kwargs = http_dialogue.reply.call_args
+        body = json.loads(call_kwargs.kwargs["body"].decode("utf-8"))
+        return {
+            "body": body,
+            "status_code": call_kwargs.kwargs["status_code"],
+        }
+
+    def test_health_no_last_transition_is_unhealthy(self) -> None:
+        """Test a frozen FSM (no last transition) reports is_healthy=False."""
         handler = _make_http_handler()
         context = handler.context
         context.params.reset_pause_duration = 60
 
-        # Mock state
+        # Wedged FSM: no last-transition timestamp, no abci_app.
         round_sequence = MagicMock()
         round_sequence._last_round_transition_timestamp = None
         round_sequence._abci_app = None
         context.state.round_sequence = round_sequence
 
-        # Mock synchronized_data
         with patch.object(
             HttpHandler,
             "synchronized_data",
             new_callable=PropertyMock,
         ) as mock_sync:
             mock_sync.return_value = MagicMock(period_count=5)
+            result = self._invoke_health(handler)
 
-            http_msg = MagicMock()
-            http_dialogue = MagicMock()
-            http_response = MagicMock()
-            http_dialogue.reply.return_value = http_response
+        body = result["body"]
+        # HTTP must always be 200; the wedge is signalled only via is_healthy.
+        assert result["status_code"] == HttpCode.OK_CODE.value
+        assert body["is_healthy"] is False
+        assert body["liveness"]["ok"] is False
+        assert body["liveness"]["reason"] == "no-fsm-data"
+        # Three-state is_tm_healthy must stay None (not coerced to True).
+        assert body["is_tm_healthy"] is None
+        assert body["seconds_since_last_transition"] is None
+        assert body["period"] == 5
+        assert body["rounds"] is None
+        assert body["is_transitioning_fast"] is None
+        assert body["readiness"] == {"ok": True, "reason": "idle-ok"}
+        assert body["progress"] == {"ok": True, "reason": "idle-ok"}
+        assert body["health_version"] == 2
 
-            handler._handle_get_health(http_msg, http_dialogue)
-
-            # Should call _send_ok_response
-            http_dialogue.reply.assert_called_once()
-            call_kwargs = http_dialogue.reply.call_args
-            body = json.loads(call_kwargs.kwargs["body"].decode("utf-8"))
-
-            assert body["seconds_since_last_transition"] is None
-            assert body["is_tm_healthy"] is True  # not is_tm_unhealthy (None)
-            assert body["period"] == 5
-            assert body["rounds"] is None
-            assert body["is_transitioning_fast"] is None
-
-    def test_health_with_last_transition(self) -> None:
-        """Test health response when last transition exists."""
+    def test_health_recent_transition_is_healthy(self) -> None:
+        """Test a live, recently-transitioned FSM reports is_healthy=True."""
         handler = _make_http_handler()
         context = handler.context
         context.params.reset_pause_duration = 60
 
-        # Mock state
         round_sequence = MagicMock()
-        timestamp = datetime.now()
-        round_sequence._last_round_transition_timestamp = timestamp
+        round_sequence._last_round_transition_timestamp = datetime.now()
         round_sequence.block_stall_deadline_expired = False
 
-        # Mock abci_app
         current_round = MagicMock()
         current_round.round_id = "CurrentRound"
         prev_round_1 = MagicMock()
         prev_round_1.round_id = "PrevRound1"
         round_sequence._abci_app.current_round = current_round
         round_sequence._abci_app._previous_rounds = [prev_round_1]
-
         context.state.round_sequence = round_sequence
 
         with patch.object(
@@ -388,23 +399,80 @@ class TestHttpHandlerGetHealth:
             new_callable=PropertyMock,
         ) as mock_sync:
             mock_sync.return_value = MagicMock(period_count=10)
+            result = self._invoke_health(handler)
 
-            http_msg = MagicMock()
-            http_dialogue = MagicMock()
-            http_response = MagicMock()
-            http_dialogue.reply.return_value = http_response
+        body = result["body"]
+        assert result["status_code"] == HttpCode.OK_CODE.value
+        assert body["is_healthy"] is True
+        assert body["liveness"]["ok"] is True
+        assert body["liveness"]["reason"] == "ok"
+        assert body["is_tm_healthy"] is True
+        assert isinstance(body["seconds_since_last_transition"], float)
+        assert body["period"] == 10
+        assert body["current_round"] == "CurrentRound"
+        assert "CurrentRound" in body["rounds"]
+        assert body["readiness"] == {"ok": True, "reason": "idle-ok"}
+        assert body["progress"] == {"ok": True, "reason": "idle-ok"}
+        assert body["health_version"] == 2
 
-            handler._handle_get_health(http_msg, http_dialogue)
+    def test_health_tm_unhealthy(self) -> None:
+        """Test a stalled Tendermint node reports liveness reason tm-unhealthy."""
+        handler = _make_http_handler()
+        context = handler.context
+        context.params.reset_pause_duration = 60
 
-            http_dialogue.reply.assert_called_once()
-            call_kwargs = http_dialogue.reply.call_args
-            body = json.loads(call_kwargs.kwargs["body"].decode("utf-8"))
+        round_sequence = MagicMock()
+        round_sequence._last_round_transition_timestamp = datetime.now()
+        round_sequence.block_stall_deadline_expired = True
+        round_sequence._abci_app = None
+        context.state.round_sequence = round_sequence
 
-            assert body["seconds_since_last_transition"] is not None
-            assert isinstance(body["seconds_since_last_transition"], float)
-            assert body["period"] == 10
-            assert body["rounds"] is not None
-            assert "CurrentRound" in body["rounds"]
+        with patch.object(
+            HttpHandler,
+            "synchronized_data",
+            new_callable=PropertyMock,
+        ) as mock_sync:
+            mock_sync.return_value = MagicMock(period_count=3)
+            result = self._invoke_health(handler)
+
+        body = result["body"]
+        assert result["status_code"] == HttpCode.OK_CODE.value
+        assert body["is_healthy"] is False
+        assert body["liveness"]["ok"] is False
+        assert body["liveness"]["reason"] == "tm-unhealthy"
+        assert body["is_tm_healthy"] is False
+        assert body["health_version"] == 2
+
+    def test_health_stale_but_has_timestamp(self) -> None:
+        """Test a stale (but timestamped) FSM reports stuck-no-transition."""
+        handler = _make_http_handler()
+        context = handler.context
+        context.params.reset_pause_duration = 60
+
+        # Last transition is far in the past (> LIVENESS_STALL_FACTOR * reset_pause).
+        stale_ts = datetime.fromtimestamp(datetime.now().timestamp() - 10_000)
+        round_sequence = MagicMock()
+        round_sequence._last_round_transition_timestamp = stale_ts
+        round_sequence.block_stall_deadline_expired = False
+        round_sequence._abci_app = None
+        context.state.round_sequence = round_sequence
+
+        with patch.object(
+            HttpHandler,
+            "synchronized_data",
+            new_callable=PropertyMock,
+        ) as mock_sync:
+            mock_sync.return_value = MagicMock(period_count=2)
+            result = self._invoke_health(handler)
+
+        body = result["body"]
+        assert result["status_code"] == HttpCode.OK_CODE.value
+        assert body["is_healthy"] is False
+        assert body["liveness"]["ok"] is False
+        assert body["liveness"]["reason"] == "stuck-no-transition"
+        assert body["is_tm_healthy"] is True
+        assert body["seconds_since_last_transition"] > 60 * 3
+        assert body["health_version"] == 2
 
 
 class TestHttpHandlerSynchronizedData:

--- a/packages/valory/skills/market_maker_abci/tests/test_handlers.py
+++ b/packages/valory/skills/market_maker_abci/tests/test_handlers.py
@@ -368,7 +368,7 @@ class TestHttpHandlerGetHealth:
         # Three-state is_tm_healthy must stay None (not coerced to True).
         assert body["is_tm_healthy"] is None
         assert body["seconds_since_last_transition"] is None
-        assert body["period"] == 5
+        assert body["period"] is None
         assert body["rounds"] is None
         assert body["is_transitioning_fast"] is None
         assert body["readiness"] == {"ok": True, "reason": "idle-ok"}


### PR DESCRIPTION
## Summary

When both market-creator instances wedged (FSM frozen 36-50h), `/healthcheck` kept returning HTTP 200 with `is_tm_healthy: true` -- a healthy report for a dead agent. Two bugs in `market_maker_abci/handlers.py` `_handle_get_health`:

1. The `if round_sequence._last_round_transition_timestamp:` guard skips all liveness computation when the FSM is frozen, leaving `is_tm_unhealthy = None`.
2. `"is_tm_healthy": not is_tm_unhealthy` then turns that `None` into `True` (`not None == True`) -- so the deadest state reports the most confident `true`. There was also no single `is_healthy` boolean for a supervisor to key on.

This ports the mech service's three-dimension health model so a frozen FSM is correctly reported as `is_healthy: false`, converging the healthcheck shape with the mech fleet.

## Changes (surgical -- only `_handle_get_health` + constants)

- **Liveness** (the dimension that catches the wedge): `seconds_since_last_transition is None or is_tm_unhealthy is None` -> `(False, "no-fsm-data")`; `is_tm_unhealthy` -> `tm-unhealthy`; `seconds > LIVENESS_STALL_FACTOR * reset_pause` -> `stuck-no-transition`; else `ok`.
- **Readiness / Progress**: market-creator is FSM-only with no task backlog (unlike mech), so both are always-ok `idle-ok` placeholders kept for shape parity. No backlog tracking invented; mech's task-specific fields (`PENDING_TASKS`, `last_tx`, etc.) are deliberately NOT copied.
- `is_healthy = bool(liveness_ok and readiness_ok and progress_ok)`.
- Fix the not-None bug: `"is_tm_healthy": (None if is_tm_unhealthy is None else not is_tm_unhealthy)` (three-state).
- Constants mirror mech: `LIVENESS_STALL_FACTOR=3.0`, `TRANSITION_TOLERANCE_FACTOR=2.0`, `HEALTH_VERSION=2`.
- **HTTP 200 always** (`_send_ok_response`). No status-code change, no auto-restart -- the wedge is signalled solely via `is_healthy: false` (operator decision). `HttpCode` enum and all other handlers untouched.
- All existing observational fields preserved; added `is_healthy`, `liveness`, `readiness`, `progress`, `current_round`, `health_version`.

## JSON emitted for the wedged state (the bug being fixed)

```json
{
  "is_healthy": false,
  "liveness": {"ok": false, "reason": "no-fsm-data"},
  "readiness": {"ok": true, "reason": "idle-ok"},
  "progress": {"ok": true, "reason": "idle-ok"},
  "seconds_since_last_transition": null,
  "is_tm_healthy": null,
  "period": 2,
  "reset_pause_duration": 600.0,
  "current_round": null,
  "rounds": null,
  "is_transitioning_fast": null,
  "health_version": 2
}
```
Previously this exact state returned `is_tm_healthy: true` and no `is_healthy` field.

## Test plan

- [x] 36 tests pass (`test_handlers.py`), incl. 4 new health-dimension cases: recent->healthy, tm-unhealthy, stale->stuck-no-transition, no-last-transition->unhealthy; every case asserts HTTP 200, `readiness`/`progress == idle-ok`, `health_version == 2`
- [x] isort / black / flake8 / darglint clean
- [x] `autonomy packages lock` cascaded (dev packages only: market_maker_abci skill/agent/service; no third-party moved)

## Context

Companion to the wedge-prevention PR (de-blocks the `approve_markets` mech call that triggers the freeze). This PR stops the healthcheck from lying about it; that PR removes the trigger. Full root-cause: `.claude/plans/healthcheck_wedge_investigation.md`.