### PR TITLE
fix(models): wire RealitioWithdrawBonds SharedState into composed MRO (crash-loop fix)

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,9 +2,9 @@
     "dev": {
         "contract/valory/fpmm_deterministic_factory/0.1.0": "bafybeiazddwzm6dc6625dkynx4devvfy5rq3fbh3vrpj4h66r7lusj6vua",
         "skill/valory/market_creation_manager_abci/0.1.0": "bafybeib7cfg3cismd55moa6ckephltavxo64drw43hlnnpfrzjmxfh4t2m",
-        "skill/valory/market_maker_abci/0.1.0": "bafybeiaucn2yy2da46zxma4ssvd7khwfr2got6ij256o7aeb3yuecjpyxi",
-        "agent/valory/market_maker/0.1.0": "bafybeibc62nbcnenwvjtlm67yirekp7exxhpn7bcc37psaww52cnaw3sgi",
-        "service/valory/market_maker/0.1.0": "bafybeies32xs4gmyiscsvrwhh5a2koufjqzefa4y2f26sc3hbrm55knoxy"
+        "skill/valory/market_maker_abci/0.1.0": "bafybeigls7vfprcn4noqohksxqsbb6rs37ylwjo3hqdxrdlyzlvfhilavu",
+        "agent/valory/market_maker/0.1.0": "bafybeihnamt5artnbolgme6luheo6zb5mprzv372rpd4gv2qzyy3qioz5y",
+        "service/valory/market_maker/0.1.0": "bafybeibb5msj3gggv2clat37k4vfpalsjr6bveym3ve6ty64ean3tpgpzy"
     },
     "third_party": {
         "protocol/valory/contract_api/1.0.0": "bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la",

--- a/packages/valory/agents/market_maker/aea-config.yaml
+++ b/packages/valory/agents/market_maker/aea-config.yaml
@@ -43,7 +43,7 @@ skills:
 - valory/funds_forwarder_abci:0.1.0:bafybeihuxw5tgnp4hie76as2jwnbp5abxrkmlmmpu4ila6ey34xrfkqqie
 - valory/identify_service_owner_abci:0.1.0:bafybeid7qw3aoorbv2bnxwd54npkgvdxf6kzpfscnmzqiui74jiskjmitm
 - valory/market_creation_manager_abci:0.1.0:bafybeib7cfg3cismd55moa6ckephltavxo64drw43hlnnpfrzjmxfh4t2m
-- valory/market_maker_abci:0.1.0:bafybeiaucn2yy2da46zxma4ssvd7khwfr2got6ij256o7aeb3yuecjpyxi
+- valory/market_maker_abci:0.1.0:bafybeigls7vfprcn4noqohksxqsbb6rs37ylwjo3hqdxrdlyzlvfhilavu
 - valory/mech_interact_abci:0.1.0:bafybeihn6ic3exr3umjl5kgmlos3d2sjy6rs3sfogvdtw5e5lenpjaxwou
 - valory/omen_ct_redeem_tokens_abci:0.1.0:bafybeif6w2bplgceactukt5b6qpth5nxspdeljsxaywrlyxvymdxxiefsq
 - valory/omen_fpmm_remove_liquidity_abci:0.1.0:bafybeibuldgtifqjst4oeremvl6huzvdnq36opgwv2wupsnplf4er5frpm

--- a/packages/valory/services/market_maker/service.yaml
+++ b/packages/valory/services/market_maker/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibwz3af6326msp4h3kqehijvmyhaytvyfbo3o2npc2w4b6zrg6pfq
 fingerprint_ignore_patterns: []
-agent: valory/market_maker:0.1.0:bafybeibc62nbcnenwvjtlm67yirekp7exxhpn7bcc37psaww52cnaw3sgi
+agent: valory/market_maker:0.1.0:bafybeihnamt5artnbolgme6luheo6zb5mprzv372rpd4gv2qzyy3qioz5y
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/market_maker_abci/models.py
+++ b/packages/valory/skills/market_maker_abci/models.py
@@ -88,6 +88,9 @@ from packages.valory.skills.omen_realitio_withdraw_bonds_abci.models import (
 from packages.valory.skills.omen_realitio_withdraw_bonds_abci.models import (
     RealitioWithdrawBondsParams,
 )
+from packages.valory.skills.omen_realitio_withdraw_bonds_abci.models import (
+    SharedState as RealitioWithdrawBondsSharedState,
+)
 from packages.valory.skills.omen_realitio_withdraw_bonds_abci.rounds import (
     Event as OmenRealitioWithdrawBondsEvent,
 )
@@ -109,12 +112,21 @@ MechToolsSpecs = BaseMechToolsSpecs
 MechsSubgraph = BaseMechsSubgraph
 
 
-class SharedState(MechInteractSharedState, BaseSharedState, CtRedeemTokensSharedState):
+class SharedState(
+    MechInteractSharedState,
+    BaseSharedState,
+    CtRedeemTokensSharedState,
+    RealitioWithdrawBondsSharedState,
+):
     """Keep the current shared state of the skill.
 
     Multi-inherits from sub-skill SharedStates so their ``__init__``
     initializers (e.g. ``ignored_ct_positions`` from the CT redeem skill,
-    and mech state from mech_interact) are run via MRO.
+    ``realitio_claim_build_cache`` from the Realitio withdraw-bonds skill,
+    and mech state from mech_interact) are run via MRO. Omitting a
+    sub-skill whose behaviour reads ``self.context.state.<attr>`` causes
+    that attribute to be absent on the composed runtime state, raising
+    ``AttributeError`` and (under ``stop_and_exit``) crash-looping.
     """
 
     abci_app_cls = MarketCreatorAbciApp  # type: ignore[assignment]

--- a/packages/valory/skills/market_maker_abci/skill.yaml
+++ b/packages/valory/skills/market_maker_abci/skill.yaml
@@ -14,13 +14,13 @@ fingerprint:
   dialogues.py: bafybeiafgwadv6kzts6yx5gtjyuvaftnofyn3rrwvczfd5seihpydzukju
   fsm_specification.yaml: bafybeif6md363gmewsuegx6254k2gnsh46p7vqa6spj5efqowc6mgccx2m
   handlers.py: bafybeiefnf5zg2tjf6mfdaz65ath6ziditzul5u3hrkpl2h5ofwdsaw3vy
-  models.py: bafybeidaxa4d7w3566mcjtiakcz5aufwuwovxnsmqfgtzf7juesksllsmu
+  models.py: bafybeiec2hpb7fngpsq7euhxuqnrprrnkabofsmdvbl2jd2nwawz7w6pty
   tests/__init__.py: bafybeibbn4ofwna62otdupfcz34fy3bgir6phq3s7q4e4cma4pfoxgeyrq
   tests/conftest.py: bafybeig6ks3pok5kcsvfetmy4f5bp5q2suxquma45bxs5cdir42rlgffyi
   tests/test_behaviours.py: bafybeiapyvud7fsne3cg2oowm2u7jni5ngixv4p3mudukisluccjzpc5l4
   tests/test_dialogues.py: bafybeiedpuwlfc24gxkjoi4wvncfnjsgc7xfqiajqmvrjdvfpfrw2bcqnm
   tests/test_handlers.py: bafybeia3adw5llfkkcugytry3l2xpn2tz4irecqoihyndrhessmic7o2nq
-  tests/test_models.py: bafybeihpplz5jpldwc3dwoiikpgq5pzfijgrparak25k722l6lw3ypifli
+  tests/test_models.py: bafybeidyfl3f2v6b4a34j3hqt2mllygpdaxnkpwjfqqozxumepp6eh2iui
 fingerprint_ignore_patterns: []
 connections:
 - valory/http_server:0.22.0:bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle

--- a/packages/valory/skills/market_maker_abci/tests/test_models.py
+++ b/packages/valory/skills/market_maker_abci/tests/test_models.py
@@ -86,6 +86,27 @@ class TestSharedState:
         """Test inheritance."""
         assert issubclass(SharedState, BaseSharedState)
 
+    def test_realitio_claim_build_cache_initialized(self) -> None:
+        """The withdraw-bonds claim cache must be initialized on the shared state.
+
+        Regression: ``RealitioWithdrawBondsBehaviour._build_claim_txs``
+        reads ``self.context.state.realitio_claim_build_cache``. That
+        attribute only exists if ``RealitioWithdrawBondsSharedState`` is in
+        this composed ``SharedState``'s MRO so its ``__init__`` runs via the
+        cooperative ``super()`` chain (same mechanism as
+        ``ignored_ct_positions``). When it was absent the round raised
+        ``AttributeError`` -> ``stop_and_exit`` -> Propel restart loop.
+        """
+        from unittest.mock import MagicMock
+
+        from packages.valory.skills.omen_realitio_withdraw_bonds_abci.models import (
+            SharedState as RealitioWithdrawBondsSharedState,
+        )
+
+        assert RealitioWithdrawBondsSharedState in SharedState.__mro__
+        state = SharedState(name="state", skill_context=MagicMock())
+        assert state.realitio_claim_build_cache == {}
+
     def test_abci_app_cls(self) -> None:
         """Test abci_app_cls is set."""
         from packages.valory.skills.market_maker_abci.composition import (


### PR DESCRIPTION
## Same crash-loop fix as market-resolver#35, applied to market-creator

After the resume-after-timeout claim cache (`omen_realitio_withdraw_bonds_abci` v0.1.2, cascaded via #230) merged, market-creator `main` was left in the same crash-prone state the resolver hit in production: the composed `market_maker_abci.SharedState` does not include the withdraw-bonds sub-skill in its MRO, so `realitio_claim_build_cache` is never initialised on the runtime `self.context.state`.

`RealitioWithdrawBondsBehaviour._build_claim_txs` reads it directly:

\`\`\`
AttributeError: 'SharedState' object has no attribute 'realitio_claim_build_cache'
-> AEAActException -> skill_exception_policy: stop_and_exit -> Propel restart loop
\`\`\`

The market-creator deployment was **not** yet bumped to the cache CID (the agent-deployments env bump was held), so this is a pre-deploy fix — no production impact, unlike the resolver.

## Fix — standard repo pattern

The composed `SharedState` already multiply-inherits `MechInteractSharedState` and `CtRedeemTokensSharedState` so their `__init__` cross-round vars (`ignored_ct_positions`, mech state) land on the runtime state. This adds `RealitioWithdrawBondsSharedState` alongside them:

\`\`\`python
class SharedState(
    MechInteractSharedState,
    BaseSharedState,
    CtRedeemTokensSharedState,
    RealitioWithdrawBondsSharedState,   # <- added
):
\`\`\`

The class docstring is updated to spell out the invariant (omitting a sub-skill whose behaviour reads `self.context.state.<attr>` crash-loops).

## Verification
\`\`\`
instantiate composed SharedState -> realitio_claim_build_cache == {}  (next to ignored_ct_positions)
\`\`\`

## Test plan
- [x] `TestSharedState` (4) incl. new regression (attr initialised + sub-skill in MRO)
- [x] `market_maker_abci` suite **58 passed**
- [x] lint green (isort/black/flake8/mypy/pylint/darglint)
- [x] structural green (check-abciapp-specs/handlers/packages)
- [x] `autonomy packages lock` cascade; `third_party` preserved

## Rollout
Merge → service CID `bafybeibb5msj3gggv2clat37k4vfpalsjr6bveym3ve6ty64ean3tpgpzy`. The held agent-deployments creator env bumps (QS + Pearl) must target this fixed CID, not #230's.